### PR TITLE
[#4] Added manual code syntax highlight and monospaced font

### DIFF
--- a/Accessibility Handbook.xcodeproj/project.pbxproj
+++ b/Accessibility Handbook.xcodeproj/project.pbxproj
@@ -106,6 +106,7 @@
 		3FC73ECE28DDDFB900D89F64 /* TheUpsideDown.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FC73ECD28DDDFB900D89F64 /* TheUpsideDown.swift */; };
 		3FC73ED028DDE1FC00D89F64 /* SuperFriend.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FC73ECF28DDE1FC00D89F64 /* SuperFriend.swift */; };
 		3FD533F328DE3DCF0058E585 /* EnableVoiceOverPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FD533F228DE3DCF0058E585 /* EnableVoiceOverPage.swift */; };
+		3FF4A29128DF540D005D291A /* SyntaxHighlight.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FF4A29028DF540D005D291A /* SyntaxHighlight.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -209,6 +210,7 @@
 		3FC73ECD28DDDFB900D89F64 /* TheUpsideDown.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TheUpsideDown.swift; sourceTree = "<group>"; };
 		3FC73ECF28DDE1FC00D89F64 /* SuperFriend.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuperFriend.swift; sourceTree = "<group>"; };
 		3FD533F228DE3DCF0058E585 /* EnableVoiceOverPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnableVoiceOverPage.swift; sourceTree = "<group>"; };
+		3FF4A29028DF540D005D291A /* SyntaxHighlight.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyntaxHighlight.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -365,6 +367,7 @@
 				3FBF057528DA701B00DA5BF5 /* PageContent.swift */,
 				3FBF05B528DB3F7C00DA5BF5 /* Space.swift */,
 				3FBF055928DA693200DA5BF5 /* Spacing.swift */,
+				3FF4A29028DF540D005D291A /* SyntaxHighlight.swift */,
 				3FBF05BA28DB48E500DA5BF5 /* Title.swift */,
 				3FBF057728DA712C00DA5BF5 /* ToAny.swift */,
 			);
@@ -712,6 +715,7 @@
 				3FBF057628DA701B00DA5BF5 /* PageContent.swift in Sources */,
 				3FBF05BB28DB48E500DA5BF5 /* Title.swift in Sources */,
 				3FBF05AE28DAC03A00DA5BF5 /* FindThePassword.swift in Sources */,
+				3FF4A29128DF540D005D291A /* SyntaxHighlight.swift in Sources */,
 				3FBF058F28DA9E3E00DA5BF5 /* ActivatePage.swift in Sources */,
 				3F4E7F9128DCA6AC00710F18 /* ChangeCursorPositionPage.swift in Sources */,
 				3FC73ECE28DDDFB900D89F64 /* TheUpsideDown.swift in Sources */,

--- a/Accessibility Handbook.xcodeproj/project.pbxproj
+++ b/Accessibility Handbook.xcodeproj/project.pbxproj
@@ -107,6 +107,7 @@
 		3FC73ED028DDE1FC00D89F64 /* SuperFriend.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FC73ECF28DDE1FC00D89F64 /* SuperFriend.swift */; };
 		3FD533F328DE3DCF0058E585 /* EnableVoiceOverPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FD533F228DE3DCF0058E585 /* EnableVoiceOverPage.swift */; };
 		3FF4A29128DF540D005D291A /* SyntaxHighlight.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FF4A29028DF540D005D291A /* SyntaxHighlight.swift */; };
+		3FF4A29328DF6D12005D291A /* CodePreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FF4A29228DF6D12005D291A /* CodePreview.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -211,6 +212,7 @@
 		3FC73ECF28DDE1FC00D89F64 /* SuperFriend.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuperFriend.swift; sourceTree = "<group>"; };
 		3FD533F228DE3DCF0058E585 /* EnableVoiceOverPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnableVoiceOverPage.swift; sourceTree = "<group>"; };
 		3FF4A29028DF540D005D291A /* SyntaxHighlight.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyntaxHighlight.swift; sourceTree = "<group>"; };
+		3FF4A29228DF6D12005D291A /* CodePreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodePreview.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -370,6 +372,7 @@
 				3FF4A29028DF540D005D291A /* SyntaxHighlight.swift */,
 				3FBF05BA28DB48E500DA5BF5 /* Title.swift */,
 				3FBF057728DA712C00DA5BF5 /* ToAny.swift */,
+				3FF4A29228DF6D12005D291A /* CodePreview.swift */,
 			);
 			path = UI;
 			sourceTree = "<group>";
@@ -795,6 +798,7 @@
 				3FBF055A28DA693200DA5BF5 /* Spacing.swift in Sources */,
 				3F4E7F8828DC97E100710F18 /* ContentHierarchySection.swift in Sources */,
 				3F4E7F8D28DC981700710F18 /* GroupingPage.swift in Sources */,
+				3FF4A29328DF6D12005D291A /* CodePreview.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Accessibility Handbook/Book/VoiceOverGuide/AccessibilityProperties/Pages/AccessibilityHintPage.swift
+++ b/Accessibility Handbook/Book/VoiceOverGuide/AccessibilityProperties/Pages/AccessibilityHintPage.swift
@@ -13,11 +13,11 @@ struct AccessibilityHintPage: View, Page {
   let title: String = strings.title
 
   let codeUIKit: String = """
-  myView.accessibilityHint = "<content>"
+  myView.accessibilityHint = "content"
   """
 
   let codeSwiftUI: String = """
-  .accessibilityHint(Text("<content>"))
+  .accessibilityHint("content")
   """
 
   let docLink: String = """

--- a/Accessibility Handbook/Book/VoiceOverGuide/AccessibilityProperties/Pages/AccessibilityValuePage.swift
+++ b/Accessibility Handbook/Book/VoiceOverGuide/AccessibilityProperties/Pages/AccessibilityValuePage.swift
@@ -17,7 +17,7 @@ struct AccessibilityValuePage: View, Page {
   @State private var currentValue: Int = 0
 
   var body: some View {
-    PageContent(next: nil) {
+    PageContent(next: AccessibilityPriorityPage()) {
       Group {
         Text("Accessibility Values represent the value (most of the times numeric) associated with your view.")
         Text("It's mostly used in components that represents quantities, like counters, sliders or quick-adds.")
@@ -26,6 +26,14 @@ struct AccessibilityValuePage: View, Page {
         AdjustableCounter(value: $currentValue)
         Comment("This example was built using the 'Adjustable Trait'.")
         InternalLink(page: AdjustablePage().page, title: "Adjustable Trait")
+        Code(
+          uiKit: """
+          myView.accessibilityValue = "value"
+          """,
+          swiftUI: """
+          View()
+          .accessibilityValue("value")
+          """)
         DocButton(link: link, title: title)
       }
       .toAny()

--- a/Accessibility Handbook/Book/VoiceOverGuide/ContentHierarchy/Pages/GroupingPage.swift
+++ b/Accessibility Handbook/Book/VoiceOverGuide/ContentHierarchy/Pages/GroupingPage.swift
@@ -132,7 +132,9 @@ private extension GroupingPage {
       Text("SwiftUI has a better wrapper to combine all children into a single accessible element.")
       Code(
         swiftUI: """
-        .accessibilityElement(children: .combine)
+        .accessibilityElement(
+          children: .combine
+        )
         """
       )
     }

--- a/Accessibility Handbook/Book/VoiceOverGuide/ContentHierarchy/Pages/ModalViewPage.swift
+++ b/Accessibility Handbook/Book/VoiceOverGuide/ContentHierarchy/Pages/ModalViewPage.swift
@@ -72,10 +72,10 @@ struct ModalViewPage: View, Page {
       Code(
         uiKit: """
         class MyView: UIView {
-            var isBeingDisplayed: Bool = true
-            override var accessibilityViewIsModal: Bool {
-                isBeingDisplayed
-            }
+          var isBeingDisplayed: Bool = true
+          override var accessibilityViewIsModal: Bool {
+            isBeingDisplayed
+          }
         }
         """
       )

--- a/Accessibility Handbook/Book/VoiceOverGuide/Interaction/Pages/CustomActionsPage.swift
+++ b/Accessibility Handbook/Book/VoiceOverGuide/Interaction/Pages/CustomActionsPage.swift
@@ -11,24 +11,24 @@ struct CustomActionsPage: View, Page {
   var title: String = "Custom Actions"
 
   let codeUIKit: String = """
-  let editAction = UIAccessibilityCustomAction(...)
-  let selectAction = UIAccessibilityCustomAction(...)
-  let deleteAction = UIAccessibilityCustomAction(...)
+  let editAction = UIAccessibilityCustomAction()
+  let selectAction = UIAccessibilityCustomAction()
+  let deleteAction = UIAccessibilityCustomAction()
 
   accessibilityCustomActions = [
-      editAction, selectAction, deleteAction
+    editAction, selectAction, deleteAction
   ]
   """
 
   let codeSwiftUI: String = """
   .accessibilityAction(named: Text("Select")) {
-      // Handle Select
+    // Handle Select
   }
   .accessibilityAction(named: Text("Edit")) {
-      // Handle Edit
+    // Handle Edit
   }
   .accessibilityAction(named: Text("Delete")) {
-      // Handle Delete
+    // Handle Delete
   }
   """
 

--- a/Accessibility Handbook/Book/VoiceOverGuide/Interaction/Pages/CustomActionsPage.swift
+++ b/Accessibility Handbook/Book/VoiceOverGuide/Interaction/Pages/CustomActionsPage.swift
@@ -16,7 +16,9 @@ struct CustomActionsPage: View, Page {
   let deleteAction = UIAccessibilityCustomAction()
 
   accessibilityCustomActions = [
-    editAction, selectAction, deleteAction
+    editAction,
+    selectAction,
+    deleteAction
   ]
   """
 

--- a/Accessibility Handbook/Book/VoiceOverGuide/Interaction/Pages/LongPressPage.swift
+++ b/Accessibility Handbook/Book/VoiceOverGuide/Interaction/Pages/LongPressPage.swift
@@ -13,15 +13,13 @@ struct LongPressPage: View, Page {
   let codeUIKit: String = """
   let gesture = UILongPressGestureRecognizer()
   myView.addGestureRecognizer(
-      UILongPressGestureRecognizer(
-          target: <Target>,
-          action: <Selector>
-      ))
+    gesture
+  )
   """
 
   let codeSwiftUI: String = """
   .onLongPressGesture {
-      /* Handle Gesture */
+    /* Handle Gesture */
   }
   """
 

--- a/Accessibility Handbook/Book/VoiceOverGuide/Interaction/Pages/MagicTapPage.swift
+++ b/Accessibility Handbook/Book/VoiceOverGuide/Interaction/Pages/MagicTapPage.swift
@@ -18,14 +18,14 @@ struct MagicTapPage: View, Page {
 
   let codeUIKit: String = """
   override func accessibilityPerformMagicTap() -> Bool {
-      /* Handle action */
-      return true
+    /* Handle action */
+    return true
   }
   """
 
   let codeSwiftUI: String = """
   .accessibilityAction(.magicTap) {
-      /* Handle action */
+    /* Handle action */
   }
   """
 

--- a/Accessibility Handbook/Book/VoiceOverGuide/Notifications/Pages/AnnouncementPage.swift
+++ b/Accessibility Handbook/Book/VoiceOverGuide/Notifications/Pages/AnnouncementPage.swift
@@ -11,11 +11,10 @@ struct AnnouncementPage: View, Page {
   var title: String = "Announcement"
 
   let codeUIKit: String = """
-  UIAccessibility.post(.announcement, argument: "Text to be read")
-  """
-
-  let codeSwiftUI: String = """
-  UIAccessibility.post(.announcement, argument: "Text to be read")
+  UIAccessibility.post(
+    .announcement,
+    argument: "Text to be read"
+  )
   """
 
   let link: String = """
@@ -50,7 +49,7 @@ struct AnnouncementPage: View, Page {
         Comment("To me, that's where the announcements shine!")
         example
         Comment("The code cells bellow are another example of announcements when you copy the code!")
-        Code(uiKit: codeUIKit, swiftUI: codeSwiftUI)
+        Code(uiKit: codeUIKit)
         DocButton(link: link, title: title)
       }
       .toAny()

--- a/Accessibility Handbook/Book/VoiceOverGuide/Notifications/Pages/ChangeCursorPositionPage.swift
+++ b/Accessibility Handbook/Book/VoiceOverGuide/Notifications/Pages/ChangeCursorPositionPage.swift
@@ -10,11 +10,6 @@ import SwiftUI
 struct ChangeCursorPositionPage: View, Page {
   var title: String = "Change Cursor Position"
 
-  let codeUIKit: String = """
-  UIAccessibility.post(.layoutChanged, argument: nil)
-  UIAccessibility.post(.screenChanged, argument: nil)
-  """
-
   let link: String = """
   https://developer.apple.com/documentation/uikit/uiaccessibility/notification/1620176-announcement
   """
@@ -57,7 +52,8 @@ private extension ChangeCursorPositionPage {
       Text("When triggering one of these notifications, we can pass as the argument the view we want the Voice-Over to focus on.")
       Code(
         uiKit: """
-        UIAccessibility.post(.layoutChanged, argument: viewToFocus)
+        UIAccessibility
+          .post(.layoutChanged, argument: viewToFocus)
         """
       )
     }
@@ -82,7 +78,9 @@ private extension ChangeCursorPositionPage {
       Text("Then, assign it to the view you want to control by using a view modifier.")
       Code(
         swiftUI: """
-        .accessibilityFocused($viewIsFocused)
+        .accessibilityFocused(
+            $viewIsFocused
+        )
         """
       )
       Text("Now you can change the focus to the view by setting the property to 'True'.")

--- a/Accessibility Handbook/Book/VoiceOverGuide/Notifications/Pages/NotifyScreenChangesPage.swift
+++ b/Accessibility Handbook/Book/VoiceOverGuide/Notifications/Pages/NotifyScreenChangesPage.swift
@@ -11,8 +11,11 @@ struct NotifyScreenChangesPage: View, Page {
   var title: String = "Notify Screen Changes"
 
   let codeUIKit: String = """
-  UIAccessibility.post(.layoutChanged, argument: nil)
-  UIAccessibility.post(.screenChanged, argument: nil)
+  UIAccessibility
+    .post(
+      .layoutChanged, //.screenChanged
+      argument: nil
+    )
   """
 
   let link: String = """

--- a/Accessibility Handbook/UI/Code.swift
+++ b/Accessibility Handbook/UI/Code.swift
@@ -14,6 +14,9 @@ struct Code: View {
   @State private var copiedUIKit: Bool = false
   @State private var copiedSwiftUI: Bool = false
 
+  @State private var uiKitSheet = false
+  @State private var swiftUISheet = false
+
   init(uiKit: String? = nil, swiftUI: String? = nil) {
     self.uiKit = uiKit
     self.swiftUI = swiftUI
@@ -23,19 +26,36 @@ struct Code: View {
     VStack(spacing: .regular) {
       if let uiKit = uiKit {
         codeBlock(code: uiKit, icon: .init(systemName: "uiwindow.split.2x1"), title: "UIKit", copied: $copiedUIKit) {
+          uiKitSheet = true
+        } onCopy: {
           animateSelection($copiedUIKit)
         }
       }
       if let swiftUI = swiftUI {
         codeBlock(code: swiftUI, icon: .init(systemName: "swift"), title: "SwiftUI", copied: $copiedSwiftUI) {
+          swiftUISheet = true
+        } onCopy: {
           animateSelection($copiedSwiftUI)
         }
       }
     }
+    .sheet(isPresented: $uiKitSheet) {
+      CodePreview(code: uiKit ?? "", title: "UIKit", icon: "uiwindow.split.2x1")
+    }
+    .sheet(isPresented: $swiftUISheet) {
+      CodePreview(code: swiftUI ?? "", title: "SwiftUI", icon: "swift")
+    }
   }
 
   @ViewBuilder
-  private func codeBlock(code: String, icon: Image, title: String, copied: Binding<Bool>, onCopy: @escaping () -> Void) -> some View {
+  private func codeBlock(
+    code: String,
+    icon: Image,
+    title: String,
+    copied: Binding<Bool>,
+    onSelection: @escaping () -> Void,
+    onCopy: @escaping () -> Void
+  ) -> some View {
     VStack(alignment: .leading, spacing: .regular) {
       HStack {
         icon
@@ -68,12 +88,14 @@ struct Code: View {
     }
     .accessibilityElement(children: .combine)
     .accessibilityLabel(Text("\(title) code example."))
-    .accessibilityHint(Text("Tap twice to copy it."))
+    .accessibilityHint(Text("Tap twice to open code in full screen, and tap three times to copy."))
     .onTapGesture {
-      copy(code: code)
-      onCopy()
+      onSelection()
     }
     .accessibilityAction {
+      onSelection()
+    }
+    .onLongPressGesture {
       copy(code: code)
       onCopy()
     }

--- a/Accessibility Handbook/UI/Code.swift
+++ b/Accessibility Handbook/UI/Code.swift
@@ -43,9 +43,12 @@ struct Code: View {
           .font(.subheadline)
         Spacer()
       }
-      Text(code)
-        .font(.callout)
-        .fixedSize(horizontal: false, vertical: true)
+      ScrollView(.horizontal, showsIndicators: false) {
+        Text(SyntaxHighlight().highlight(code: code))
+          .font(.callout.monospaced())
+          .frame(maxWidth: .infinity)
+          .fixedSize(horizontal: false, vertical: true)
+      }
     }
     .padding()
     .background {

--- a/Accessibility Handbook/UI/CodePreview.swift
+++ b/Accessibility Handbook/UI/CodePreview.swift
@@ -1,0 +1,99 @@
+//
+//  CodePreview.swift
+//  Accessibility Handbook
+//
+//  Created by Giovani Nascimento Pereira on 24/09/22.
+//
+
+import SwiftUI
+
+struct CodePreview: View {
+  let code: String
+  let title: String
+  let icon: String
+
+  @Environment(\.dismiss) var dismiss
+
+  var body: some View {
+    VStack(spacing: .zero) {
+      closeButton
+      titleView
+      VerticalSpace(.large)
+      codeView
+      VerticalSpace(.large)
+      copyButon
+      Spacer()
+    }
+  }
+}
+
+private extension CodePreview {
+  var codeView: some View {
+    Text(SyntaxHighlight().highlight(code: code))
+      .font(.callout.monospaced())
+      .fixedSize(horizontal: false, vertical: true)
+      .padding()
+  }
+
+  var closeButton: some View {
+    HStack {
+      Spacer()
+      Button {
+        dismiss()
+      } label: {
+        Image(systemName: "xmark")
+      }
+      .accessibilityLabel("Close code view")
+    }
+    .padding()
+  }
+
+  var titleView: some View {
+    HStack {
+      HorizontalSpace(.regular)
+      Image(systemName: icon)
+      Text(title)
+        .font(.subheadline)
+      Spacer()
+    }
+    .padding()
+  }
+
+  var separator: some View {
+    Rectangle()
+      .foregroundColor(.tertiaryBackground)
+      .accessibilityHidden(true)
+      .frame(height: .single)
+      .padding(.horizontal)
+  }
+
+  var buttonsStack: some View {
+    HStack {
+      Image(systemName: icon)
+      Text(title)
+        .font(.subheadline)
+      Spacer()
+    }
+  }
+
+  var copyButon: some View {
+    Centered {
+      Button {
+        copy(code: code)
+      } label: {
+        HStack {
+          Image(systemName: "doc.on.doc.fill")
+          Text("Copy code")
+        }
+      }
+      .toAny()
+    }
+  }
+
+  func copy(code: String) {
+    UIPasteboard.general.string = code
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+      UIAccessibility.post(notification: .announcement, argument: "Code copied!")
+    }
+  }
+}

--- a/Accessibility Handbook/UI/SyntaxHighlight.swift
+++ b/Accessibility Handbook/UI/SyntaxHighlight.swift
@@ -1,0 +1,94 @@
+//
+//  SyntaxHighlight.swift
+//  Accessibility Handbook
+//
+//  Created by Giovani Nascimento Pereira on 24/09/22.
+//
+
+import SwiftUI
+
+// This is a syntax highlighter based in Regexes.
+// And... probably it's not great,
+// But we can discuss evolutions on the syntax highlight at.
+final class SyntaxHighlight {
+  private var text: String = ""
+  private var highlighted: NSMutableAttributedString = .init()
+
+  func highlight(code: String) -> AttributedString {
+    self.text = code
+    self.highlighted = .init(string: code)
+
+    keywords()
+    names()
+    types()
+    numbers()
+    subProperties()
+    strings()
+    comments()
+
+    return AttributedString(highlighted)
+  }
+}
+
+private extension SyntaxHighlight {
+  func keywords() {
+    highlight(match: "func ", color: .systemPink, bolded: true)
+    highlight(match: "override ", color: .systemPink, bolded: true)
+    highlight(match: "return", color: .systemPink, bolded: true)
+    highlight(match: "class ", color: .systemPink, bolded: true)
+    highlight(match: "struct ", color: .systemPink, bolded: true)
+    highlight(match: "let ", color: .systemPink, bolded: true)
+    highlight(match: "var ", color: .systemPink, bolded: true)
+    highlight(match: "switch ", color: .systemPink, bolded: true)
+    highlight(match: "case ", color: .systemPink, bolded: true)
+    highlight(match: "true", color: .systemPurple, bolded: true)
+    highlight(match: "false", color: .systemPurple, bolded: true)
+    highlight(match: "@[A-Za-z]*", color: .systemPink, bolded: true)
+  }
+
+  func types() {
+    highlight(match: ": [A-Z][A-Za-z]*", color: .systemBlue, bolded: true)
+    highlight(match: ":", color: .label, bolded: true)
+    highlight(match: "-> [A-Z][A-Za-z]*", color: .systemBlue, bolded: true)
+    highlight(match: "->", color: .label, bolded: true)
+    highlight(match: "$[A-Za-z]*", color: .systemBlue, bolded: true)
+  }
+
+  func numbers() {
+    highlight(match: "[ ][0-9]+", color: .systemOrange)
+  }
+
+  func names() {
+    highlight(match: "[ ][A-Z][A-Za-z]+", color: .systemPurple)
+    highlight(match: "^[A-Z][A-Za-z]+", color: .systemPurple)
+  }
+
+  func comments() {
+    highlight(match: "//.*", color: .systemGreen)
+    highlight(match: "/\\*.*\\*/", color: .systemGreen)
+  }
+
+  func strings() {
+    highlight(match: "\".*\"", color: .systemRed)
+  }
+
+  func subProperties() {
+    highlight(match: "\\.[A-Za-z]+", color: .systemBlue)
+    highlight(match: "\\.", color: .label)
+  }
+
+  func highlight(match: String, color: UIColor, bolded: Bool = false) {
+    let pattern = match
+    let inString = text
+    let regex = try? NSRegularExpression(pattern: pattern, options: [])
+    let range = NSMakeRange(0, inString.count)
+    let matches = (regex?.matches(in: inString, options: [], range: range))!
+
+    for match in matches {
+      highlighted.addAttributes([
+        .foregroundColor: color,
+        .font: UIFont.monospacedSystemFont(ofSize: 16.0, weight: bolded ? .bold : .regular)
+      ], range: match.range)
+    }
+  }
+}

--- a/Accessibility Handbook/UI/SyntaxHighlight.swift
+++ b/Accessibility Handbook/UI/SyntaxHighlight.swift
@@ -43,6 +43,8 @@ private extension SyntaxHighlight {
     highlight(match: "case ", color: .systemPink, bolded: true)
     highlight(match: "true", color: .systemPurple, bolded: true)
     highlight(match: "false", color: .systemPurple, bolded: true)
+    highlight(match: "if ", color: .systemPurple, bolded: true)
+    highlight(match: "else ", color: .systemPurple, bolded: true)
     highlight(match: "@[A-Za-z]*", color: .systemPink, bolded: true)
   }
 
@@ -64,8 +66,8 @@ private extension SyntaxHighlight {
   }
 
   func comments() {
-    highlight(match: "//.*", color: .systemGreen)
-    highlight(match: "/\\*.*\\*/", color: .systemGreen)
+    highlight(match: "//.*", color: .systemGray)
+    highlight(match: "/\\*.*\\*/", color: .systemGray)
   }
 
   func strings() {


### PR DESCRIPTION
- #4  

### About

- We are adding a monospaced font to the code examples.
- Also, adding a custom syntax highlighter based in regexes.
- Some of the code has been altered to be better visualized on smaller devices.

### Evidences

#### Syntax Highlight

| Before | After |
|--|--|
|  <img width="550" alt="Screen Shot 2022-09-24 at 14 06 13" src="https://user-images.githubusercontent.com/12978176/192110239-3eaef2d4-3c58-4456-8297-263fcd19ffae.png"> | <img width="550" alt="Screen Shot 2022-09-24 at 13 23 50" src="https://user-images.githubusercontent.com/12978176/192108709-60e0310d-b269-4817-982e-279956cafb65.png">  |

##### New code preview

| <img width="550" alt="Screen Shot 2022-09-24 at 13 53 22" src="https://user-images.githubusercontent.com/12978176/192110056-cf0906e1-1f11-4801-9732-a0872224dff9.png"> |  <img width="550" alt="Screen Shot 2022-09-24 at 14 00 42" src="https://user-images.githubusercontent.com/12978176/192110062-7577e345-9651-4187-b574-83c176cddc6a.png"> |  <img width="550" alt="Screen Shot 2022-09-24 at 14 00 55" src="https://user-images.githubusercontent.com/12978176/192110069-8f28cac4-fc41-4a64-bf6c-1bb930b1f9dd.png">  |
|--|--|--|
