### PR TITLE
Create UIContentSizeCategoryPage

### DIFF
--- a/Accessibility Handbook.xcodeproj/project.pbxproj
+++ b/Accessibility Handbook.xcodeproj/project.pbxproj
@@ -24,6 +24,8 @@
 		3F4E7F9328DCB46700710F18 /* AdjustableCounter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4E7F9228DCB46700710F18 /* AdjustableCounter.swift */; };
 		3F4E7F9528DCBC1600710F18 /* ImageAsset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4E7F9428DCBC1600710F18 /* ImageAsset.swift */; };
 		3F4E7F9728DCCFE500710F18 /* AColorfulMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4E7F9628DCCFE500710F18 /* AColorfulMessage.swift */; };
+		3F54B62B28EE0D3400574932 /* UIContentSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F54B62A28EE0D3400574932 /* UIContentSize.swift */; };
+		3F54B62D28EE1B6A00574932 /* UIContentSizeCategory+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F54B62C28EE1B6A00574932 /* UIContentSizeCategory+Extensions.swift */; };
 		3F6C5ABA28E3748A00B12065 /* MultiFingerSwipe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F6C5AB928E3748A00B12065 /* MultiFingerSwipe.swift */; };
 		3F6C5ABC28E37FED00B12065 /* MultiFingerTap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F6C5ABB28E37FED00B12065 /* MultiFingerTap.swift */; };
 		3F6C5ABF28E394D000B12065 /* AboutFontsPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F6C5ABE28E394D000B12065 /* AboutFontsPage.swift */; };
@@ -150,6 +152,8 @@
 		3F4E7F9228DCB46700710F18 /* AdjustableCounter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdjustableCounter.swift; sourceTree = "<group>"; };
 		3F4E7F9428DCBC1600710F18 /* ImageAsset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageAsset.swift; sourceTree = "<group>"; };
 		3F4E7F9628DCCFE500710F18 /* AColorfulMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AColorfulMessage.swift; sourceTree = "<group>"; };
+		3F54B62A28EE0D3400574932 /* UIContentSize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIContentSize.swift; sourceTree = "<group>"; };
+		3F54B62C28EE1B6A00574932 /* UIContentSizeCategory+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIContentSizeCategory+Extensions.swift"; sourceTree = "<group>"; };
 		3F6C5AB928E3748A00B12065 /* MultiFingerSwipe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiFingerSwipe.swift; sourceTree = "<group>"; };
 		3F6C5ABB28E37FED00B12065 /* MultiFingerTap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiFingerTap.swift; sourceTree = "<group>"; };
 		3F6C5ABE28E394D000B12065 /* AboutFontsPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutFontsPage.swift; sourceTree = "<group>"; };
@@ -308,6 +312,7 @@
 			isa = PBXGroup;
 			children = (
 				3F6C5ABE28E394D000B12065 /* AboutFontsPage.swift */,
+				3F54B62A28EE0D3400574932 /* UIContentSize.swift */,
 			);
 			path = Pages;
 			sourceTree = "<group>";
@@ -445,6 +450,7 @@
 				3FBF057728DA712C00DA5BF5 /* ToAny.swift */,
 				3FF4A29A28DF93B1005D291A /* Icons.swift */,
 				3FF4A29C28DF93F3005D291A /* String+Extensions.swift */,
+				3F54B62C28EE1B6A00574932 /* UIContentSizeCategory+Extensions.swift */,
 			);
 			path = UI;
 			sourceTree = "<group>";
@@ -819,6 +825,7 @@
 			files = (
 				3FBF05D828DB545700DA5BF5 /* ContrastPage.swift in Sources */,
 				3FBF056528DA6A4400DA5BF5 /* AccessibilityPropertiesSection.swift in Sources */,
+				3F54B62B28EE0D3400574932 /* UIContentSize.swift in Sources */,
 				3FBF05F828DB6F5400DA5BF5 /* HapticsSection.swift in Sources */,
 				3FBF05A528DAB9C700DA5BF5 /* Storage.swift in Sources */,
 				3F41DB0E28E2553E00E0B056 /* HorizontalSwipe.swift in Sources */,
@@ -882,6 +889,7 @@
 				3FBF05C328DB4F2200DA5BF5 /* DynamicFontSections.swift in Sources */,
 				3FBF05C528DB4F3D00DA5BF5 /* ColorsSections.swift in Sources */,
 				3FB6C0FF28DA6367000A5503 /* Accessibility_HandbookApp.swift in Sources */,
+				3F54B62D28EE1B6A00574932 /* UIContentSizeCategory+Extensions.swift in Sources */,
 				3FBF05BD28DB4A8A00DA5BF5 /* CollaborationView.swift in Sources */,
 				3FBF055D28DA69F800DA5BF5 /* Page.swift in Sources */,
 				3FBF059328DA9E4E00DA5BF5 /* AdjustablePage.swift in Sources */,

--- a/Accessibility Handbook/Book/DynamicFonts/DynamicFontsSection/Pages/IdentifyCurrentPreferredFontSizePage.swift
+++ b/Accessibility Handbook/Book/DynamicFonts/DynamicFontsSection/Pages/IdentifyCurrentPreferredFontSizePage.swift
@@ -10,18 +10,8 @@ import SwiftUI
 struct IdentifyCurrentPreferredFontSizePage: View, Page {
   let title: String = L10n.IdentifyCurrentPreferredFontSizePage.title
 
-  @State private var size: ContentSizes = .xs
-  @State private var sliderValue: Double = 0.0
-  @State private var largerAccessibilitySizes: Bool = false
-
-  var scale: ClosedRange<Double> {
-    switch largerAccessibilitySizes {
-    case true:
-      return 0...12
-    case false:
-      return 0...6
-    }
-  }
+  @State private var size: UIContentSizeCategory = UIApplication.shared.preferredContentSizeCategory
+  @State private var type: SystemFontType = .body
 
   var body: some View {
     PageContent(next: nil) {
@@ -29,7 +19,6 @@ struct IdentifyCurrentPreferredFontSizePage: View, Page {
         intro
         variations
         example
-        list
         doc
       }
       .toAny()
@@ -73,40 +62,31 @@ private extension IdentifyCurrentPreferredFontSizePage {
     }
   }
 
-  var list: some View {
-    Group {
-      Title(L10n.IdentifyCurrentPreferredFontSizePage.List.title)
-      ForEach(ContentSizes.allCases, id: \.rawValue) { size in
-        Text(size.name)
-          .font(.system(size: size.fontSize))
-          Divider()
-      }
-    }
-  }
-
   var example: some View {
     Group {
-      Comment(L10n.IdentifyCurrentPreferredFontSizePage.Variations.comment1)
-      HStack {
-        Spacer()
-        Toggle(L10n.IdentifyCurrentPreferredFontSizePage.Example.toggle, isOn: $largerAccessibilitySizes)
-      }
       Centered {
         VStack(spacing: .regular) {
           Text("Aa")
-            .font(.system(size: size.fontSize).bold())
+            .font(.system(size: size.sizes[type] ?? .zero).bold())
             .accessibilityHidden(true)
-          Comment(size.name)
+          Comment(L10n.fontSize("\(size.sizes[type] ?? .zero)"))
+            .fixedSize(horizontal: false, vertical: true)
+
+          Picker("Selected content size", selection: $size) {
+            ForEach(UIContentSizeCategory.allCases, id: \.title) { category in
+              Text(category.title).tag(category)
+                .font(.callout.bold())
+            }
+          }
+
+          Picker("Selected font type", selection: $type) {
+            ForEach(SystemFontType.allCases, id: \.rawValue) { type in
+              Text(type.rawValue).tag(type)
+                .font(.callout.bold())
+            }
+          }
         }
         .toAny()
-      }
-
-      Slider(value: $sliderValue, in: scale) {
-        Text("Selected content size")
-      } minimumValueLabel: {
-        Text(L10n.minimum)
-      } maximumValueLabel: {
-        Text(L10n.maximum)
       }
     }
     .padding()
@@ -114,97 +94,9 @@ private extension IdentifyCurrentPreferredFontSizePage {
       RoundedRectangle(cornerRadius: 8.0)
         .foregroundColor(.secondaryBackground)
     }
-    .onChange(of: sliderValue) { newValue in
-      let rounded = round(newValue)
-      size = ContentSizes(rawValue: rounded) ?? .xs
-    }
-    .onChange(of: largerAccessibilitySizes) { newValue in
-      guard !newValue, size.rawValue >= ContentSizes.a_m.rawValue else { return }
-      sliderValue = ContentSizes.xxxl.rawValue
-      size = .xxxl
-    }
   }
 
   var doc: some View {
     DocButton(link: "https://developer.apple.com/documentation/uikit/uicontentsizecategory", title: "UIContentSizeCategory")
-  }
-}
-
-private extension IdentifyCurrentPreferredFontSizePage {
-  enum ContentSizes: CGFloat, CaseIterable {
-    case xs = 10.0
-    case s = 13.0
-    case m = 16.0
-    case l = 18.0
-    case xl = 19.0
-    case xxl = 20.0
-    case xxxl = 22.0
-    case a_m = 30.0
-    case a_l = 35.0
-    case a_xl = 40.0
-    case a_xxl = 45.0
-    case a_xxxl = 50.0
-
-    init?(rawValue: CGFloat) {
-      switch rawValue {
-      case 0..<1:
-        self = .xs
-      case 1..<2:
-        self = .s
-      case 2..<3:
-        self = .m
-      case 3..<4:
-        self = .l
-      case 4..<5:
-        self = .xl
-      case 5..<6:
-        self = .xxl
-      case 6..<7:
-        self = .xxxl
-      case 7..<8:
-        self = .a_m
-      case 8..<9:
-        self = .a_l
-      case 9..<10:
-        self = .a_xl
-      case 10..<11:
-        self = .a_xxl
-      default:
-        self = .a_xxxl
-      }
-    }
-
-    var name: String {
-      switch self {
-      case .xs:
-        return "extra small"
-      case .s:
-        return "small"
-      case .m:
-        return "medium"
-      case .l:
-        return "large"
-      case .xl:
-        return "extra large"
-      case .xxl:
-        return "extra extra large"
-      case .xxxl:
-        return "extra extra extra large"
-      case .a_m:
-        return "accessibility medium"
-      case .a_l:
-        return "accessibility large"
-      case .a_xl:
-        return "accessibility extra large"
-      case .a_xxl:
-        return "accessibility extra extra large"
-      case .a_xxxl:
-        return "accessibility extra extra extra large"
-      }
-    }
-
-    var fontSize: CGFloat {
-      rawValue
-    }
   }
 }

--- a/Accessibility Handbook/Book/DynamicFonts/Fonts/FontsSection.swift
+++ b/Accessibility Handbook/Book/DynamicFonts/Fonts/FontsSection.swift
@@ -11,5 +11,6 @@ struct FontsSection: Section {
   var title: String = L10n.Fonts.title
   var pages: [Page] = [
     AboutFontsPage(),
+    UIContentSizePage()
   ]
 }

--- a/Accessibility Handbook/Book/DynamicFonts/Fonts/Pages/AboutFontsPage.swift
+++ b/Accessibility Handbook/Book/DynamicFonts/Fonts/Pages/AboutFontsPage.swift
@@ -11,7 +11,7 @@ struct AboutFontsPage: View, Page {
   let title: String = L10n.AboutFonts.title
 
   var body: some View {
-    PageContent(next: nil) {
+    PageContent(next: UIContentSizePage()) {
       Group {
         intro
         ExternalLink(link: "https://www.dafont.com", title: L10n.AboutFonts.link)

--- a/Accessibility Handbook/Book/DynamicFonts/Fonts/Pages/UIContentSize.swift
+++ b/Accessibility Handbook/Book/DynamicFonts/Fonts/Pages/UIContentSize.swift
@@ -1,0 +1,110 @@
+//
+//  UIContentSize.swift
+//  Accessibility Handbook
+//
+//  Created by Giovani Nascimento Pereira on 05/10/22.
+//
+
+import SwiftUI
+
+struct UIContentSizePage: View, Page {
+  let title: String = L10n.UIContentSizeCategory.title
+
+  var body: some View {
+    PageContent(next: nil) {
+      Group {
+        intro
+        list
+        items
+        Divider()
+        code
+        link
+      }
+      .toAny()
+    }
+  }
+}
+
+private extension UIContentSizePage {
+  var intro: some View {
+    Group {
+      Text(L10n.UIContentSizeCategory.Intro.text1)
+      Text(L10n.UIContentSizeCategory.Intro.text2)
+      Comment(L10n.UIContentSizeCategory.Intro.comment1)
+    }
+  }
+
+  var list: some View {
+    Group {
+      Title(L10n.UIContentSizeCategory.List.title)
+      Text(L10n.UIContentSizeCategory.List.text1)
+      InternalLink(page: IdentifyCurrentPreferredFontSizePage().page, title: L10n.IdentifyCurrentPreferredFontSizePage.title)
+      Comment(L10n.UIContentSizeCategory.List.comment1)
+      InternalLink(page: ScallingFontsAutomaticallyPage().page, title: L10n.ImplementingDynamicFonts.title)
+      VerticalSpace(.regular)
+    }
+  }
+
+  var items: some View {
+    ForEach(UIContentSizeCategory.allCases, id: \.title) { category in
+      Title(category.title.capitalized)
+      let current = category == UIApplication.shared.preferredContentSizeCategory
+      if current { currentMarker }
+      ScrollView([.horizontal], showsIndicators: true) {
+        HStack(spacing: .large) {
+          ForEach(SystemFontType.allCases, id: \.rawValue) { type in
+            item(category: category, type: type)
+          }
+        }
+        VerticalSpace(.regular)
+      }
+    }
+  }
+
+  var currentMarker: some View {
+    Text(L10n.UIContentSizeCategory.List.current)
+      .multilineTextAlignment(.center)
+      .padding()
+      .background {
+        RoundedRectangle(cornerRadius: 8.0)
+          .foregroundColor(.accentColor.opacity(0.3))
+      }
+      .fixedSize(horizontal: false, vertical: true)
+  }
+
+  @ViewBuilder
+  func item(category: UIContentSizeCategory, type item: SystemFontType) -> some View {
+    let fontSize = category.sizes[item] ?? .zero
+    let current = category == UIApplication.shared.preferredContentSizeCategory
+    VStack(alignment: .center, spacing: .small) {
+      Text("Aa")
+        .font(.system(size: fontSize))
+      VerticalSpace(.regular)
+      Text(item.name)
+      Comment(L10n.fontSize("\(fontSize)"))
+    }
+    .frame(minWidth: 100.0)
+    .padding()
+    .background {
+      RoundedRectangle(cornerRadius: 8.0)
+        .foregroundColor(current ? .accentColor.opacity(0.3) : .secondaryBackground)
+    }
+    .accessibilityElement(children: .ignore)
+    .accessibilityLabel([category.title, item.name, L10n.fontSize("\(fontSize)")].joined(separator: .commaSpace))
+  }
+
+  var code: some View {
+    Group {
+      Text(L10n.UIContentSizeCategory.Code.text1)
+      Code.uikit(
+        """
+        UIFont.preferredFont(forTextStyle: .body).pointSize
+        """
+      )
+    }
+  }
+
+  var link: some View {
+    DocButton(link: "https://developer.apple.com/documentation/uikit/uicontentsizecategory", title: title)
+  }
+}

--- a/Accessibility Handbook/Strings/Strings.swift
+++ b/Accessibility Handbook/Strings/Strings.swift
@@ -70,6 +70,10 @@ internal enum L10n {
   internal static let flag = L10n.tr("Localizable", "flag")
   /// Fog
   internal static let fog = L10n.tr("Localizable", "fog")
+  /// Font size: %@
+  internal static func fontSize(_ p1: Any) -> String {
+    return L10n.tr("Localizable", "fontSize", String(describing: p1))
+  }
   /// Free shipping
   internal static let freeShipping = L10n.tr("Localizable", "freeShipping")
   /// Go Back
@@ -1754,6 +1758,33 @@ internal enum L10n {
     internal static let text2 = L10n.tr("Localizable", "TheUpsideDown.text2")
     /// The Upside Down
     internal static let title = L10n.tr("Localizable", "TheUpsideDown.title")
+  }
+
+  internal enum UIContentSizeCategory {
+    /// UIContentSizeCategory
+    internal static let title = L10n.tr("Localizable", "UIContentSizeCategory.title")
+    internal enum Code {
+      /// You can check the system's font size by using the following code.
+      internal static let text1 = L10n.tr("Localizable", "UIContentSizeCategory.Code.text1")
+    }
+    internal enum Intro {
+      /// The accessibility sizes are larger than the other ones, even if their name starts at 'accessibility medium' it's still larger than the regular 'extra extra extra large' size.
+      internal static let comment1 = L10n.tr("Localizable", "UIContentSizeCategory.Intro.comment1")
+      /// The 'UIContentSizeCategory' is a system enum that represents the user's selected preferred content size.
+      internal static let text1 = L10n.tr("Localizable", "UIContentSizeCategory.Intro.text1")
+      /// It has 12 different size options from extra small to extra extra extra large, then the 'accessibility sizes' from accessibility medium to accessibility extra extra extra large. (Yep, 3 extras)
+      internal static let text2 = L10n.tr("Localizable", "UIContentSizeCategory.Intro.text2")
+    }
+    internal enum List {
+      /// Although, on code, usually you should not check this information directly and just use the UIFontMetric or system fonts to scale your font to the correct size.
+      internal static let comment1 = L10n.tr("Localizable", "UIContentSizeCategory.List.comment1")
+      /// This is your current content size.
+      internal static let current = L10n.tr("Localizable", "UIContentSizeCategory.List.current")
+      /// Here's a list of all the available content size categories. You can check the 'Identify preferred content size' page to get more information on how to properly identify them.
+      internal static let text1 = L10n.tr("Localizable", "UIContentSizeCategory.List.text1")
+      /// List of UIContentSizeCategory
+      internal static let title = L10n.tr("Localizable", "UIContentSizeCategory.List.title")
+    }
   }
 
   internal enum UIFontMetrics {

--- a/Accessibility Handbook/Strings/en.lproj/Localizable.strings
+++ b/Accessibility Handbook/Strings/en.lproj/Localizable.strings
@@ -841,6 +841,22 @@
 "AboutFonts.Intro.comment4" = "And that's where accessibility comes and it gets interesting.";
 "AboutFonts.link" = "Check some different fonts!";
 
+// UIContentSizeCategory
+
+"UIContentSizeCategory.title" = "UIContentSizeCategory";
+"UIContentSizeCategory.Intro.text1" = "The 'UIContentSizeCategory' is a system enum that represents the user's selected preferred content size.";
+"UIContentSizeCategory.Intro.text2" = "It has 12 different size options from extra small to extra extra extra large, then the 'accessibility sizes' from accessibility medium to accessibility extra extra extra large. (Yep, 3 extras)";
+"UIContentSizeCategory.Intro.comment1" = "The accessibility sizes are larger than the other ones, even if their name starts at 'accessibility medium' it's still larger than the regular 'extra extra extra large' size.";
+
+"UIContentSizeCategory.List.title" = "List of UIContentSizeCategory";
+"UIContentSizeCategory.List.text1" = "Here's a list of all the available content size categories. You can check the 'Identify preferred content size' page to get more information on how to properly identify them.";
+"UIContentSizeCategory.List.comment1" = "Although, on code, usually you should not check this information directly and just use the UIFontMetric or system fonts to scale your font to the correct size.";
+"UIContentSizeCategory.List.current" = "This is your current content size.";
+
+"UIContentSizeCategory.Code.text1" = "You can check the system's font size by using the following code.";
+
+"fontSize" = "Font size: %@";
+
 // Size And Weight
 
 "SizeAndWeight.title" = "Size and Weight";

--- a/Accessibility Handbook/Strings/pt-BR.lproj/Localizable.strings
+++ b/Accessibility Handbook/Strings/pt-BR.lproj/Localizable.strings
@@ -841,6 +841,22 @@
 "AboutFonts.Intro.comment4" = "E é aí que acessibilidade começa a ficar interessante";
 "AboutFonts.link" = "Veja mais fontes online.";
 
+// UIContentSizeCategory
+
+"UIContentSizeCategory.title" = "UIContentSizeCategory";
+"UIContentSizeCategory.Intro.text1" = "O 'UIContentSizeCategory' é um enum do sistema que representa o tamanho preferido de fontes selecionado pelo usuário.";
+"UIContentSizeCategory.Intro.text2" = "Ele tem 12 opções diferentes de tamanho, de extra pequeno até extra extra extra grande. E então, os 'tamanhos de acessibilidade' de 'accessibility medium' até 'accessibility extra extra extra large' (Isso mesmo, 3 extras).";
+"UIContentSizeCategory.Intro.comment1" = "Os tamanhos de acessibilidade são maiores que os demais, mesmo que o nome do menos deles seja 'accessibility medium', ele ainda é maior que o tamanho 'extra extra extra grande'.";
+
+"UIContentSizeCategory.List.title" = "Lista de UIContentSizeCategory";
+"UIContentSizeCategory.List.text1" = "Aqui segue uma lista de todos os tamanhos disponíveis no sistems. Você pode ver a página 'Identificar tamanho de fonte selecionado' para mais informações.";
+"UIContentSizeCategory.List.comment1" = "Mas, no código, geralmente não devemos verificar qual o tamanho esperado da fonte, apenas deixar que ele escale nosso conteúdo corretamente, seja usando o UIFontMetric ou as fontes definidas do sistema.";
+"UIContentSizeCategory.List.current" = "Este é o seu 'content size' atual.";
+
+"UIContentSizeCategory.Code.text1" = "Você pode verificar o tamanho das fontes do sistema usando o código a seguir.";
+
+"fontSize" = "Tamanho da fonte: %@";
+
 // Size And Weight
 
 "SizeAndWeight.title" = "Peso e Tamanho";

--- a/Accessibility Handbook/UI/String+Extensions.swift
+++ b/Accessibility Handbook/UI/String+Extensions.swift
@@ -10,4 +10,5 @@ import Foundation
 extension String {
   static let space = " "
   static let empty = ""
+  static let commaSpace = ", "
 }

--- a/Accessibility Handbook/UI/UIContentSizeCategory+Extensions.swift
+++ b/Accessibility Handbook/UI/UIContentSizeCategory+Extensions.swift
@@ -1,0 +1,134 @@
+//
+//  UIContentSizeCategory+Extensions.swift
+//  Accessibility Handbook
+//
+//  Created by Giovani Nascimento Pereira on 05/10/22.
+//
+
+import UIKit
+
+extension UIContentSizeCategory: CaseIterable {
+  public static var allCases: [UIContentSizeCategory] {
+    [
+      .extraSmall, .small, .medium, .large, .extraLarge, .extraExtraLarge, .extraExtraExtraLarge,
+      .accessibilityMedium, .accessibilityLarge, .accessibilityExtraLarge, .accessibilityExtraExtraLarge, .accessibilityExtraExtraExtraLarge
+    ]
+  }
+
+  var title: String {
+    switch self {
+    case .extraSmall:
+      return "extra small"
+    case .small:
+      return "small"
+    case .medium:
+      return "medium"
+    case .large:
+      return "large"
+    case .extraLarge:
+      return "extra large"
+    case .extraExtraLarge:
+      return "extra extra large"
+    case .extraExtraExtraLarge:
+      return "extra extra extra large"
+    case .accessibilityMedium:
+      return "accessibility medium"
+    case .accessibilityLarge:
+      return "accessibility large"
+    case .accessibilityExtraLarge:
+      return "accessibility extra large"
+    case .accessibilityExtraExtraLarge:
+      return "accessibility extra extra large"
+    case .accessibilityExtraExtraExtraLarge:
+      return "accessibility extra extra extra large"
+    case .unspecified:
+      return "unspecified"
+    default:
+      return .empty
+    }
+  }
+
+  var sizes: [SystemFontType: CGFloat] {
+    switch self {
+    case .extraSmall:
+      return SystemFontType.all(body: 14.0, title1: 25.0, title2: 19.0, title3: 17.0, largeTitle: 31.0, caption1: 11.0, caption2: 11.0, callout: 13.0, footnote: 12.0, headline: 14.0, subheadline: 12.0)
+    case .small:
+      return SystemFontType.all(body: 15.0, title1: 26.0, title2: 20.0, title3: 18.0, largeTitle: 32.0, caption1: 11.0, caption2: 11.0, callout: 14.0, footnote: 12.0, headline: 15.0, subheadline: 13.0)
+    case .medium:
+      return SystemFontType.all(body: 16.0, title1: 27.0, title2: 21.0, title3: 19.0, largeTitle: 33.0, caption1: 11.0, caption2: 11.0, callout: 15.0, footnote: 12.0, headline: 16.0, subheadline: 14.0)
+    case .large:
+      return SystemFontType.all(body: 17.0, title1: 28.0, title2: 22.0, title3: 20.0, largeTitle: 34.0, caption1: 12.0, caption2: 11.0, callout: 16.0, footnote: 13.0, headline: 17.0, subheadline: 15.0)
+    case .extraLarge:
+      return SystemFontType.all(body: 19.0, title1: 30.0, title2: 24.0, title3: 22.0, largeTitle: 36.0, caption1: 14.0, caption2: 13.0, callout: 18.0, footnote: 15.0, headline: 19.0, subheadline: 17.0)
+    case .extraExtraLarge:
+      return SystemFontType.all(body: 21.0, title1: 32.0, title2: 26.0, title3: 24.0, largeTitle: 38.0, caption1: 16.0, caption2: 15.0, callout: 20.0, footnote: 17.0, headline: 21.0, subheadline: 19.0)
+    case .extraExtraExtraLarge:
+      return SystemFontType.all(body: 23.0, title1: 34.0, title2: 28.0, title3: 26.0, largeTitle: 40.0, caption1: 18.0, caption2: 17.0, callout: 22.0, footnote: 19.0, headline: 23.0, subheadline: 21.0)
+    case .accessibilityMedium:
+      return SystemFontType.all(body: 28.0, title1: 38.0, title2: 34.0, title3: 31.0, largeTitle: 44.0, caption1: 22.0, caption2: 20.0, callout: 26.0, footnote: 23.0, headline: 28.0, subheadline: 25.0)
+    case .accessibilityLarge:
+      return SystemFontType.all(body: 33.0, title1: 43.0, title2: 39.0, title3: 37.0, largeTitle: 48.0, caption1: 26.0, caption2: 24.0, callout: 32.0, footnote: 27.0, headline: 33.0, subheadline: 30.0)
+    case .accessibilityExtraLarge:
+      return SystemFontType.all(body: 40.0, title1: 48.0, title2: 44.0, title3: 43.0, largeTitle: 52.0, caption1: 32.0, caption2: 29.0, callout: 38.0, footnote: 33.0, headline: 40.0, subheadline: 36.0)
+    case .accessibilityExtraExtraLarge:
+      return SystemFontType.all(body: 47.0, title1: 53.0, title2: 50.0, title3: 49.0, largeTitle: 56.0, caption1: 37.0, caption2: 34.0, callout: 44.0, footnote: 38.0, headline: 47.0, subheadline: 42.0)
+    case .accessibilityExtraExtraExtraLarge:
+      return SystemFontType.all(body: 53.0, title1: 58.0, title2: 56.0, title3: 55.0, largeTitle: 60.0, caption1: 43.0, caption2: 40.0, callout: 51.0, footnote: 44.0, headline: 53.0, subheadline: 49.0)
+    case .unspecified:
+      return SystemFontType.all(body: 0, title1: 0, title2: 0, title3: 0, largeTitle: 0, caption1: 0, caption2: 0, callout: 0, footnote: 0, headline: 0, subheadline: 0)
+    default:
+      return SystemFontType.all(body: 0, title1: 0, title2: 0, title3: 0, largeTitle: 0, caption1: 0, caption2: 0, callout: 0, footnote: 0, headline: 0, subheadline: 0)
+    }
+  }
+}
+
+struct ContentSizeCategoryItem {
+  let name: String
+  let size: CGFloat
+}
+
+enum SystemFontType: String, CaseIterable {
+  case body
+  case title1
+  case title2
+  case title3
+  case largeTitle
+  case caption1
+  case caption2
+  case callout
+  case footnote
+  case headline
+  case subheadline
+
+  var name: String {
+    self.rawValue
+  }
+
+  static func all(
+    body: CGFloat,
+    title1: CGFloat,
+    title2: CGFloat,
+    title3: CGFloat,
+    largeTitle: CGFloat,
+    caption1: CGFloat,
+    caption2: CGFloat,
+    callout: CGFloat,
+    footnote: CGFloat,
+    headline: CGFloat,
+    subheadline: CGFloat
+  ) -> [SystemFontType: CGFloat] {
+    [
+      .body: body,
+      .title1: title1,
+      .title2: title2,
+      .title3: title3,
+      .largeTitle: largeTitle,
+      .caption1: caption1,
+      .caption2: caption2,
+      .callout: callout,
+      .footnote: footnote,
+      .headline: headline,
+      .subheadline: subheadline
+    ]
+  }
+}


### PR DESCRIPTION
### Summary
- We are creating a new documentation page to display the system default font sizes for each size category

### Implementation details
- We have mapped manually each size, and created a new page in the Dynamic fonts section in order to display it

### How to test it?
- Run the app
- Go to Dynamic fonts > UIContentSizeCategory

### Evidences
|  <img width="550" alt="Screen Shot 2022-10-05 at 18 42 26" src="https://user-images.githubusercontent.com/12978176/194169783-6d8185b5-10ec-4f26-aa8f-5f2ea7fe415a.png">  |  <img width="550" alt="Screen Shot 2022-10-05 at 18 42 32" src="https://user-images.githubusercontent.com/12978176/194169796-b42d3e33-5d7f-4a5e-9db5-1d3834917676.png"> |  <img width="550" alt="Screen Shot 2022-10-05 at 18 42 39" src="https://user-images.githubusercontent.com/12978176/194169803-14060868-a0c6-4212-b0ac-7078518b7912.png"> |
|--|--|--|


---


<!--
Add the associated Issue number in order to close it once this PR is merged.
all issues: https://github.com/giovaninppc/AccessibilityHandbook/issues
-->
closes #31  

<!--
Thanks for helping us improve the Accessibility Handbook! New releases usually come out every week in the AppStore (if we have updates)
-->
