### PR TITLE
#6: fixed frame home screen tile on smaller devices.

### DIFF
--- a/Accessibility Handbook/Home/HomeView.swift
+++ b/Accessibility Handbook/Home/HomeView.swift
@@ -205,7 +205,7 @@ private extension HomeView {
         Spacer()
       }
       .accessibilityElement(children: .combine)
-      .frame(minWidth: 150.0, minHeight: 150.0)
+      .frame(maxWidth: UIScreen.main.bounds.width / 2, minHeight: 150.0)
       .padding()
       .background {
         RoundedRectangle(cornerRadius: 8.0)


### PR DESCRIPTION
### Summary
Changed frame calculation of `HomeView.homeElement(icon:title:destination:)` to use `maxWidth` parameter based on screen device width.

### Implementation details
Previously the frame's min width was set to `150` which did not fit onto the smallest device's screen when having two in one row side-by-side.

### How to test it?
Run the app on small + large devices.

### Evidences

iPod touch (smallest device):
![image](https://user-images.githubusercontent.com/35889530/195170112-ce4a4b90-aaa4-4952-aeca-4cd13eaf6b3b.png)

iPhone 11:
![image](https://user-images.githubusercontent.com/35889530/195170344-1b50057b-c94c-4a75-a280-19e29248066d.png)

iPhone 13 Pro Max (largest one available on my old Xcode setup):
![image](https://user-images.githubusercontent.com/35889530/195170808-abbabc7a-bb40-4555-8544-f2982e37586d.png)


---


<!--
Add the associated Issue number in order to close it once this PR is merged.
all issues: https://github.com/giovaninppc/AccessibilityHandbook/issues
-->
closes #6 

<!--
Thanks for helping us improve the Accessibility Handbook! New releases usually come out every week in the AppStore (if we have updates)
-->
