### PR TITLE
Creates Image Trait page

### DIFF
--- a/Accessibility Handbook.xcodeproj/project.pbxproj
+++ b/Accessibility Handbook.xcodeproj/project.pbxproj
@@ -141,6 +141,7 @@
 		3FF4A29B28DF93B1005D291A /* Icons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FF4A29A28DF93B1005D291A /* Icons.swift */; };
 		3FF4A29D28DF93F3005D291A /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FF4A29C28DF93F3005D291A /* String+Extensions.swift */; };
 		3FF4A29E28E10ED1005D291A /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 3FF4A2A028E10ED1005D291A /* Localizable.strings */; };
+		9DD4F902290B635300A00E51 /* ImageTraitPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DD4F901290B635300A00E51 /* ImageTraitPage.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -280,6 +281,7 @@
 		3FF4A29C28DF93F3005D291A /* String+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extensions.swift"; sourceTree = "<group>"; };
 		3FF4A29F28E10ED1005D291A /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		3FF4A2A128E10EDD005D291A /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		9DD4F901290B635300A00E51 /* ImageTraitPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageTraitPage.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -743,6 +745,7 @@
 				3FBF060428DB71BA00DA5BF5 /* ListOfAccessibilityTraitsPage.swift */,
 				3FBF060228DB710300DA5BF5 /* ButtonTraitPage.swift */,
 				3FBF060828DB8C4C00DA5BF5 /* HeaderTraitPage.swift */,
+				9DD4F901290B635300A00E51 /* ImageTraitPage.swift */,
 			);
 			path = Pages;
 			sourceTree = "<group>";
@@ -953,6 +956,7 @@
 				3F41C11728E49CBB0092CF28 /* UIFontMetricsPage.swift in Sources */,
 				3FBF05DA28DB56D000DA5BF5 /* BePatient.swift in Sources */,
 				3F4E7F9528DCBC1600710F18 /* ImageAsset+extensions.swift in Sources */,
+				9DD4F902290B635300A00E51 /* ImageTraitPage.swift in Sources */,
 				3FBF05B428DB3BDD00DA5BF5 /* AccessibilityPriorityPage.swift in Sources */,
 				3FBF060128DB704600DA5BF5 /* InternalLink.swift in Sources */,
 				3FBF05EA28DB699200DA5BF5 /* IncreaseContrastPage.swift in Sources */,

--- a/Accessibility Handbook/Book/VoiceOverGuide/AccessibilityTraits/AccessibilityTraitsSection.swift
+++ b/Accessibility Handbook/Book/VoiceOverGuide/AccessibilityTraits/AccessibilityTraitsSection.swift
@@ -12,6 +12,7 @@ struct AccessibilityTraitsSection: Section {
   let pages: [Page] = [
     ListOfAccessibilityTraitsPage(),
     ButtonTraitPage(),
-    HeaderTraitPage()
+    HeaderTraitPage(),
+    ImageTraitPage()
   ]
 }

--- a/Accessibility Handbook/Book/VoiceOverGuide/AccessibilityTraits/Pages/ImageTraitPage.swift
+++ b/Accessibility Handbook/Book/VoiceOverGuide/AccessibilityTraits/Pages/ImageTraitPage.swift
@@ -1,0 +1,43 @@
+//
+//  ImageTraitPage.swift
+//  Accessibility Handbook
+//
+//  Created by Maria Fernanda Azolin on 27/10/22.
+//
+
+import SwiftUI
+
+struct ImageTraitPage: View, Page {
+    let title: String = L10n.ImageTrait.title
+
+  let codeUIKit: String = """
+  myView.accessibilityTraits = [.image]
+  """
+
+  let codeSwiftUI: String = """
+  .accessibilityAddTraits([.isImage])
+  """
+
+  let link: String = """
+  https://developer.apple.com/documentation/uikit/uiaccessibilitytraits/1620174-image
+  """
+
+  var body: some View {
+    PageContent(next: nil) {
+      Group {
+        Text(L10n.ImageTrait.text1)
+        Text(L10n.ImageTrait.text2)
+        Text(L10n.ImageTrait.text3)
+        Asset.prettyColors.swiftUIImage
+            .resizable()
+            .aspectRatio(contentMode: .fit)
+            .accessibilityLabel(L10n.ImageTrait.description)
+        Code.uikit(codeUIKit)
+        Code.swiftUI(codeSwiftUI)
+        DocButton(link: link, title: title)
+      }
+      .toAny()
+    }
+  }
+}
+

--- a/Accessibility Handbook/Book/VoiceOverGuide/AccessibilityTraits/Pages/ListOfAccessibilityTraitsPage.swift
+++ b/Accessibility Handbook/Book/VoiceOverGuide/AccessibilityTraits/Pages/ListOfAccessibilityTraitsPage.swift
@@ -64,7 +64,7 @@ struct ListOfAccessibilityTraitsPage: View, Page {
       listItem(
         name: "image",
         description: L10n.ListOfTraits.image,
-        internalLink: nil,
+        internalLink: ImageTraitPage().page,
         externalLink: "https://developer.apple.com/documentation/uikit/uiaccessibilitytraits/1620174-image"
       )
 

--- a/Accessibility Handbook/Strings/Strings.swift
+++ b/Accessibility Handbook/Strings/Strings.swift
@@ -623,6 +623,19 @@ internal enum L10n {
     /// Button Trait
     internal static let title = L10n.tr("Localizable", "ButtonTrait.title")
   }
+    
+    internal enum ImageTrait {
+        /// Image description
+        internal static let description = L10n.tr("Localizable", "ImageTrait.description", "Image description")
+        /// The image trait is good for images or other visual elements that have no text or action.
+        internal static let text1 = L10n.tr("Localizable", "ImageTrait.text1", "The image trait is good for images or other visual elements that have no text or action.")
+        /// If you are using an Image or an UIImage it will automatically have the image trait. However, you may also want to apply this trait to other elements, such as graphics or animations.
+        internal static let text2 = L10n.tr("Localizable", "ImageTrait.text2", "If you are using an Image or an UIImage it will automatically have the image trait. However, you may also want to apply this trait to other elements, such as graphics or animations.")
+        /// This will make the Voice Over to identify and read the element as an image.
+        internal static let text3 = L10n.tr("Localizable", "ImageTrait.text3", "This will make the Voice Over to identify and read the element as an image.")
+        /// Image Trait
+        internal static let title = L10n.tr("Localizable", "ImageTrait.title", "Image Trait")
+    }
 
   internal enum ChangeCursor {
     /// Change cursor position

--- a/Accessibility Handbook/Strings/en.lproj/Localizable.strings
+++ b/Accessibility Handbook/Strings/en.lproj/Localizable.strings
@@ -218,6 +218,16 @@
 "ButtonTrait.additionalInformation" = "Additional information";
 "ButtonTrait.cellTapped" = "This cell was tapped";
 
+// Image trait
+
+"ImageTrait.title" = "Image Trait";
+
+"ImageTrait.text1" = "The image trait is good for images or other visual elements that have no text or action.";
+"ImageTrait.text2" = "If you are using an Image or an UIImage it will automatically have the image trait. However, you may also want to apply this trait to other elements, such as graphics or animations.";
+"ImageTrait.text3" = "This will make the Voice Over to identify and read the element as an image.";
+
+"ImageTrait.description" = "Image description";
+
 // Adjustable
 
 "Adjustable.title" = "Adjustable trait";

--- a/Accessibility Handbook/Strings/pt-BR.lproj/Localizable.strings
+++ b/Accessibility Handbook/Strings/pt-BR.lproj/Localizable.strings
@@ -218,6 +218,16 @@
 "ButtonTrait.additionalInformation" = "Informação adicional";
 "ButtonTrait.cellTapped" = "A célula foi clicada";
 
+// Image trait
+
+"ImageTrait.title" = "Image Trait";
+
+"ImageTrait.text1" = "O trait de imagem serve para imagens ou outros elementos visuais que não contém nenhum texto ou ação.";
+"ImageTrait.text2" = "Se você está usando uma Image ou uma UIImage, ela vai automaticamente ter o trait de imagem. Entretanto, você pode querer aplicar esse trait também em outros elementos que façam sentido, como, por exemplo, um gráfico ou uma animação.";
+"ImageTrait.text3" = "Isso fará o Voice Over identificar e ler o elemento como uma imagem.";
+
+"ImageTrait.description" = "Descrição da imagem";
+
 // Adjustable
 
 "Adjustable.title" = "Adjustable trait";


### PR DESCRIPTION
### Summary
This PR creates an `Image Trait` page on the `Accessibility Traits` section inside the `Voice Over guide`.

### How to test it?
Opening the image trait page inside the voice over guide menu. The page should display the contents correctly and have accessibility enabled and working.

### Evidences

<img src="https://user-images.githubusercontent.com/49958403/198451996-acf06421-a274-49a3-83de-2a624a465287.png" width="400" />

<!--
Thanks for helping us improve the Accessibility Handbook! New releases usually come out every week in the AppStore (if we have updates)
-->
