### PR TITLE
[#19] Add bolded text section and page

### DIFF
--- a/Accessibility Handbook.xcodeproj/project.pbxproj
+++ b/Accessibility Handbook.xcodeproj/project.pbxproj
@@ -130,6 +130,7 @@
 		3FC73ED028DDE1FC00D89F64 /* SuperFriend.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FC73ECF28DDE1FC00D89F64 /* SuperFriend.swift */; };
 		3FC7F92E290C09C8006C8185 /* VisualAidSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FC7F92D290C09C8006C8185 /* VisualAidSection.swift */; };
 		3FC7F931290C0A03006C8185 /* ButtonShapes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FC7F930290C0A03006C8185 /* ButtonShapes.swift */; };
+		3FC7F933290C117B006C8185 /* BoldedText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FC7F932290C117B006C8185 /* BoldedText.swift */; };
 		3FD00F6228E3B61A0007D604 /* ImplementDynamicFontsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FD00F6128E3B61A0007D604 /* ImplementDynamicFontsSection.swift */; };
 		3FD00F6928E3B6700007D604 /* ScalingFontsAutomaticallyPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FD00F6828E3B6700007D604 /* ScalingFontsAutomaticallyPage.swift */; };
 		3FD533F328DE3DCF0058E585 /* EnableVoiceOverPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FD533F228DE3DCF0058E585 /* EnableVoiceOverPage.swift */; };
@@ -271,6 +272,7 @@
 		3FC73ECF28DDE1FC00D89F64 /* SuperFriend.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuperFriend.swift; sourceTree = "<group>"; };
 		3FC7F92D290C09C8006C8185 /* VisualAidSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisualAidSection.swift; sourceTree = "<group>"; };
 		3FC7F930290C0A03006C8185 /* ButtonShapes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonShapes.swift; sourceTree = "<group>"; };
+		3FC7F932290C117B006C8185 /* BoldedText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoldedText.swift; sourceTree = "<group>"; };
 		3FD00F6128E3B61A0007D604 /* ImplementDynamicFontsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImplementDynamicFontsSection.swift; sourceTree = "<group>"; };
 		3FD00F6828E3B6700007D604 /* ScalingFontsAutomaticallyPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScalingFontsAutomaticallyPage.swift; sourceTree = "<group>"; };
 		3FD533F228DE3DCF0058E585 /* EnableVoiceOverPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnableVoiceOverPage.swift; sourceTree = "<group>"; };
@@ -777,6 +779,7 @@
 			isa = PBXGroup;
 			children = (
 				3FC7F930290C0A03006C8185 /* ButtonShapes.swift */,
+				3FC7F932290C117B006C8185 /* BoldedText.swift */,
 			);
 			path = Pages;
 			sourceTree = "<group>";
@@ -920,6 +923,7 @@
 				3FBF05AE28DAC03A00DA5BF5 /* FindThePassword.swift in Sources */,
 				3FD00F6228E3B61A0007D604 /* ImplementDynamicFontsSection.swift in Sources */,
 				3FC3E5EF28E3334A00B7C0D7 /* MultiTap.swift in Sources */,
+				3FC7F933290C117B006C8185 /* BoldedText.swift in Sources */,
 				3FF4A29128DF540D005D291A /* SyntaxHighlight.swift in Sources */,
 				3FBF058F28DA9E3E00DA5BF5 /* ActivatePage.swift in Sources */,
 				3F4E7F9128DCA6AC00710F18 /* ChangeCursorPositionPage.swift in Sources */,

--- a/Accessibility Handbook/Book/Others/VisualAid/Pages/BoldedText.swift
+++ b/Accessibility Handbook/Book/Others/VisualAid/Pages/BoldedText.swift
@@ -1,0 +1,54 @@
+//
+//  BoldedText.swift
+//  Accessibility Handbook
+//
+//  Created by Giovani Nascimento Pereira on 28/10/22.
+//
+
+import SwiftUI
+
+struct BoldedTextPage: View, Page {
+  let title: String = L10n.BoldedText.title
+
+  var body: some View {
+    PageContent(next: nil) {
+      Group {
+        intro
+        code
+        reference
+      }
+      .toAny()
+    }
+  }
+}
+
+private extension BoldedTextPage {
+  @ViewBuilder
+  var intro: some View {
+    Text(L10n.BoldedText.Intro.text1)
+    Text(L10n.BoldedText.Intro.text2)
+    Text(L10n.BoldedText.Intro.text3)
+    Comment(L10n.BoldedText.Intro.comment1)
+  }
+
+  @ViewBuilder
+  var code: some View {
+    Code.uikit(
+      """
+      let isBoldTextEnabled = UIAccessibility.isBoldTextEnabled
+      UIFont.systemFont(
+        ofSize: 16.0,
+        weight: isBoldTextEnabled ? .bold : .regular
+      )
+      """
+    )
+    Text(L10n.BoldedText.Code.text1)
+    Comment(L10n.BoldedText.Code.comment1)
+    ExternalLink(link: UIApplication.openSettingsURLString, title: L10n.openSettings)
+  }
+
+  @ViewBuilder
+  var reference: some View {
+    DocButton(link: "https://developer.apple.com/documentation/uikit/uiaccessibility/1615156-isboldtextenabled", title: self.title)
+  }
+}

--- a/Accessibility Handbook/Book/Others/VisualAid/Pages/ButtonShapes.swift
+++ b/Accessibility Handbook/Book/Others/VisualAid/Pages/ButtonShapes.swift
@@ -14,7 +14,7 @@ struct ButtonShapesPage: View, Page {
   var buttonShapesEnabled: Bool
 
   var body: some View {
-    PageContent(next: nil) {
+    PageContent(next: BoldedTextPage()) {
       Group {
         intro
         example

--- a/Accessibility Handbook/Book/Others/VisualAid/VisualAidSection.swift
+++ b/Accessibility Handbook/Book/Others/VisualAid/VisualAidSection.swift
@@ -10,6 +10,7 @@ import Foundation
 struct VisualAidSection: Section {
   let title: String = L10n.visualAid
   let pages: [Page] = [
-    ButtonShapesPage()
+    ButtonShapesPage(),
+    BoldedTextPage()
   ]
 }

--- a/Accessibility Handbook/Strings/Strings.swift
+++ b/Accessibility Handbook/Strings/Strings.swift
@@ -607,6 +607,27 @@ internal enum L10n {
     internal static let title = L10n.tr("Localizable", "BePatient.title")
   }
 
+  internal enum BoldedText {
+    /// Bolded Text
+    internal static let title = L10n.tr("Localizable", "BoldedText.title")
+    internal enum Code {
+      /// This app fully supports bolded fonts, change the accessibility option on the device's setting and check how the app behaves.
+      internal static let comment1 = L10n.tr("Localizable", "BoldedText.Code.comment1")
+      /// It's also important to notice that fonts that are already bold, become even 'bolder' when manually adjusting these changes.
+      internal static let text1 = L10n.tr("Localizable", "BoldedText.Code.text1")
+    }
+    internal enum Intro {
+      /// When using custom fonts, you may need to manually define it's weight when necessary.
+      internal static let comment1 = L10n.tr("Localizable", "BoldedText.Intro.comment1")
+      /// "Bolded Text" is another accessibility option that can be enabled on the system settings.
+      internal static let text1 = L10n.tr("Localizable", "BoldedText.Intro.text1")
+      /// It's mainly used by people with lower vision to help reading content on your app by enlarging the font's weight.
+      internal static let text2 = L10n.tr("Localizable", "BoldedText.Intro.text2")
+      /// When using system fonts, they will automatically adapt themselves to the user's defined setting for the weight.
+      internal static let text3 = L10n.tr("Localizable", "BoldedText.Intro.text3")
+    }
+  }
+
   internal enum ButtonShapes {
     /// Button Shapes
     internal static let title = L10n.tr("Localizable", "ButtonShapes.title")

--- a/Accessibility Handbook/Strings/en.lproj/Localizable.strings
+++ b/Accessibility Handbook/Strings/en.lproj/Localizable.strings
@@ -1101,3 +1101,15 @@
 "ButtonShapes.Code.text1" = "If you need to identify to make any manual changes on your content, you can use a static variable on UIKit or an Environment variable on SwiftUI.";
 
 "button" = "Button";
+
+// Bolded Text
+
+"BoldedText.title" = "Bolded Text";
+
+"BoldedText.Intro.text1" = "\"Bolded Text\" is another accessibility option that can be enabled on the system settings.";
+"BoldedText.Intro.text2" = "It's mainly used by people with lower vision to help reading content on your app by enlarging the font's weight.";
+"BoldedText.Intro.text3" = "When using system fonts, they will automatically adapt themselves to the user's defined setting for the weight.";
+"BoldedText.Intro.comment1" = "When using custom fonts, you may need to manually define it's weight when necessary.";
+
+"BoldedText.Code.text1" = "It's also important to notice that fonts that are already bold, become even 'bolder' when manually adjusting these changes.";
+"BoldedText.Code.comment1" = "This app fully supports bolded fonts, change the accessibility option on the device's setting and check how the app behaves.";

--- a/Accessibility Handbook/Strings/pt-BR.lproj/Localizable.strings
+++ b/Accessibility Handbook/Strings/pt-BR.lproj/Localizable.strings
@@ -1101,3 +1101,15 @@
 "ButtonShapes.Code.text1" = "Casso você presice identificar manualmente o estado dessa feature para atualizar seu conteúdo, você pode usar a variável estática do UIAccessibility no UIKit, ou a variável de ambiente em SwiftUI.";
 
 "button" = "Botão";
+
+// Bolded Text
+
+"BoldedText.title" = "Texto em Negrito";
+
+"BoldedText.Intro.text1" = "\"Texto em Negrito\" é outra opção de acessibilidade que pode ser ativada nas configurações do sistema.";
+"BoldedText.Intro.text2" = "É geralmente usada por pessoas que têm baixa visão com o intuito de aumentar o peso da fonte e deixar o conteúdo mais fácil de ser lido.";
+"BoldedText.Intro.text3" = "Quando usando fontes do sistema, elas irão de adaptar automaticamente ao estilo definido pelo usuário.";
+"BoldedText.Intro.comment1" = "Quando usando fontes customizadas, você pode precisar ajustar manualmente o peso da fonte considerando se esta opção está habilitada.";
+
+"BoldedText.Code.text1" = "Também é importante perceber que fontes que já estão em negrito, também aumentam seu peso quando esta opção está ativada..";
+"BoldedText.Code.comment1" = "Este app suporta a opção de texto em negrito, mude essa opção nas configurações do seu dispositivo e veja como o app se comporta.";


### PR DESCRIPTION
### Summary
- New `Bolded text` page

### Evidences

| <img width="550" alt="Screen Shot 2022-10-28 at 10 55 50" src="https://user-images.githubusercontent.com/12978176/198626989-4307b8a6-0e4e-4afb-b5f7-e436c0f18f4b.png"> | <img width="506" alt="Screen Shot 2022-10-28 at 10 56 03" src="https://user-images.githubusercontent.com/12978176/198627018-38adc323-13b0-42a2-b328-b69a5a21514e.png"> |
|--|--|

---

closes #19 

