### PR TITLE
Search Improvements

### DIFF
--- a/Accessibility Handbook/Book/Index/IndexCell.swift
+++ b/Accessibility Handbook/Book/Index/IndexCell.swift
@@ -38,7 +38,7 @@ struct IndexCell: View {
   private var displayTitle: some View {
     Group {
       if let icon = icon {
-        (Text(icon) + Text(String.space) + Text(title))
+        (Text(icon) + Text("   ") + Text(title))
       } else {
         Text(title)
       }

--- a/Accessibility Handbook/Home/AllPagesProvider.swift
+++ b/Accessibility Handbook/Home/AllPagesProvider.swift
@@ -5,15 +5,39 @@
 //  Created by Giovani Nascimento Pereira on 29/10/22.
 //
 
-import Foundation
+import SwiftUI
 
 struct AllPagesProvider {
-  var allPages: [Page] {
+  let allPages: [Page] = {
     let guideSections = VoiceOverGuideSections().sections + ColorsSection().sections
       + OthersSections().sections + DynamicFontSections().sections
     let guidePages = guideSections.map { $0.pages }.flatMap { $0 }
     let gamePages = Games.pages
     let aboutPages: [Page] = [AboutTheAppView(), CollaborationView()]
-    return guidePages + gamePages + aboutPages
-  }
+    let group = guidePages + gamePages + aboutPages
+    return group.sorted { $0.title < $1.title }
+  }()
+
+  let pageIconDict: [String: Image] = {
+    var dict: [String: Image] = [:]
+    VoiceOverGuideSections().sections.map { $0.pages }.flatMap { $0 }.forEach { voiceOverPage in
+      dict[voiceOverPage.id] = Icon.book
+    }
+    ColorsSection().sections.map { $0.pages }.flatMap { $0 }.forEach { colorPage in
+      dict[colorPage.id] = Icon.paintpalete
+    }
+    OthersSections().sections.map { $0.pages }.flatMap { $0 }.forEach { othersPage in
+      dict[othersPage.id] = Icon.circleHexagonpath
+    }
+    DynamicFontSections().sections.map { $0.pages }.flatMap { $0 }.forEach { dynamicFontPage in
+      dict[dynamicFontPage.id] = Icon.textformat
+    }
+    Games.pages.forEach { game in
+      dict[game.id] = Icon.gameController
+    }
+    dict[AboutTheAppView().id] = Icon.questionMarkDashed
+    dict[CollaborationView().id] = Icon.textRedaction
+
+    return dict
+  }()
 }

--- a/Accessibility Handbook/Home/HomeView.swift
+++ b/Accessibility Handbook/Home/HomeView.swift
@@ -143,7 +143,7 @@ private extension HomeView {
 private extension HomeView {
   private var aboutCell: some View {
     homeElement(
-      icon: Icon.questionMarkDsahed,
+      icon: Icon.questionMarkDashed,
       title: L10n.AboutTheApp.title,
       destination: AboutTheAppView().toAny()
     )

--- a/Accessibility Handbook/Strings/Strings.swift
+++ b/Accessibility Handbook/Strings/Strings.swift
@@ -1876,6 +1876,8 @@ internal enum L10n {
 
   internal enum Search {
     internal enum Empty {
+      /// Search all pages
+      internal static let action = L10n.tr("Localizable", "Search.Empty.action")
       /// Try changing your search!
       internal static let message = L10n.tr("Localizable", "Search.Empty.message")
       /// No results could be found

--- a/Accessibility Handbook/Strings/en.lproj/Localizable.strings
+++ b/Accessibility Handbook/Strings/en.lproj/Localizable.strings
@@ -15,6 +15,7 @@
 
 "Search.Empty.title" = "No results could be found";
 "Search.Empty.message" = "Try changing your search!";
+"Search.Empty.action" = "Search all pages";
 
 // Home
 

--- a/Accessibility Handbook/Strings/pt-BR.lproj/Localizable.strings
+++ b/Accessibility Handbook/Strings/pt-BR.lproj/Localizable.strings
@@ -15,6 +15,7 @@
 
 "Search.Empty.title" = "Nenhum resultado encontrado";
 "Search.Empty.message" = "Tente mudar a sua pesquisa!";
+"Search.Empty.action" = "Pesquisar em todas as páginas";
 
 // Home
 

--- a/Accessibility Handbook/UI/Icons.swift
+++ b/Accessibility Handbook/UI/Icons.swift
@@ -45,7 +45,7 @@ enum Icon {
 
   // State
   static let checkmark = Image(systemName: "checkmark.circle.fill")
-  static let questionMarkDsahed = Image(systemName: "questionmark.app.dashed")
+  static let questionMarkDashed = Image(systemName: "questionmark.app.dashed")
 
   // Action
   static let copy = Image(systemName: "doc.on.doc.fill")


### PR DESCRIPTION
### Summary
- We are doing some improvements on the search
- Just so it feels nicer

### Implementation details
- The content is now sorted alphabetically when searching
- Every cell has the icon of its respective section when displayed
- Added a new empty state when no match is found for the search
- A new search button on the home screen forces the display of the search bar
> I was not able to force the focus on the search bar (yet) since it's not directly accessible since it's part of a navigation property, but I think it will help to show that we do have a search field

### How to test it?
- Run the app and tap the search icon on the navigation bar
- The search bar should be displayed
- Search for anything
- If the search has content, the cells should be displayed in alphabetical order with its respective icon on the leading position
- If the search does not have any results, the new empty state should be displayed

### Evidence

| <img width="550" alt="Screen Shot 2022-10-30 at 09 48 16" src="https://user-images.githubusercontent.com/12978176/198879740-2831705f-81d8-4197-9987-282a03eff8b9.png">  |  <img width="550" alt="Screen Shot 2022-10-30 at 09 48 24" src="https://user-images.githubusercontent.com/12978176/198879741-799dda39-be19-4bd3-980b-d82cfe2a240a.png">  |  <img width="550" alt="Screen Shot 2022-10-30 at 09 52 53" src="https://user-images.githubusercontent.com/12978176/198879743-9acefc52-b2c5-46a4-b536-246e6da1ec36.png">  |
|--|--|--|

