### PR TITLE
Home redesign V2.0 (iPad + iPhone landscape)

### DIFF
--- a/Accessibility Handbook.xcodeproj/project.pbxproj
+++ b/Accessibility Handbook.xcodeproj/project.pbxproj
@@ -122,6 +122,8 @@
 		3FBF060D28DB9CE100DA5BF5 /* RotorAndHeadersPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FBF060C28DB9CE100DA5BF5 /* RotorAndHeadersPage.swift */; };
 		3FBF061028DBAB9100DA5BF5 /* FontsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FBF060F28DBAB9100DA5BF5 /* FontsSection.swift */; };
 		3FC1C36B28EC5DD500C1E009 /* IncreasingHints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FC1C36A28EC5DD500C1E009 /* IncreasingHints.swift */; };
+		3FC3D7042919E5A1007393DE /* PhoneHomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FC3D7032919E5A1007393DE /* PhoneHomeView.swift */; };
+		3FC3D7062919E651007393DE /* PadHomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FC3D7052919E651007393DE /* PadHomeView.swift */; };
 		3FC3E5E728E323E900B7C0D7 /* VerticalSwipe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FC3E5E628E323E900B7C0D7 /* VerticalSwipe.swift */; };
 		3FC3E5E928E3267600B7C0D7 /* GesturesPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FC3E5E828E3267600B7C0D7 /* GesturesPage.swift */; };
 		3FC3E5EB28E32B7300B7C0D7 /* SingleTap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FC3E5EA28E32B7300B7C0D7 /* SingleTap.swift */; };
@@ -272,6 +274,8 @@
 		3FBF060C28DB9CE100DA5BF5 /* RotorAndHeadersPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RotorAndHeadersPage.swift; sourceTree = "<group>"; };
 		3FBF060F28DBAB9100DA5BF5 /* FontsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontsSection.swift; sourceTree = "<group>"; };
 		3FC1C36A28EC5DD500C1E009 /* IncreasingHints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IncreasingHints.swift; sourceTree = "<group>"; };
+		3FC3D7032919E5A1007393DE /* PhoneHomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneHomeView.swift; sourceTree = "<group>"; };
+		3FC3D7052919E651007393DE /* PadHomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PadHomeView.swift; sourceTree = "<group>"; };
 		3FC3E5E628E323E900B7C0D7 /* VerticalSwipe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerticalSwipe.swift; sourceTree = "<group>"; };
 		3FC3E5E828E3267600B7C0D7 /* GesturesPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GesturesPage.swift; sourceTree = "<group>"; };
 		3FC3E5EA28E32B7300B7C0D7 /* SingleTap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleTap.swift; sourceTree = "<group>"; };
@@ -440,6 +444,8 @@
 				3FBF055228DA64D000DA5BF5 /* HomeView.swift */,
 				3FC9F62A290C3A4A002CC6C3 /* SearchView.swift */,
 				3FCA322B290D5F2E00551CD0 /* AllPagesProvider.swift */,
+				3FC3D7032919E5A1007393DE /* PhoneHomeView.swift */,
+				3FC3D7052919E651007393DE /* PadHomeView.swift */,
 			);
 			path = Home;
 			sourceTree = "<group>";
@@ -1004,6 +1010,7 @@
 				3FBF05D228DB516400DA5BF5 /* AboutColorsPage.swift in Sources */,
 				3F6C5ABF28E394D000B12065 /* AboutFontsPage.swift in Sources */,
 				3FBF060728DB890900DA5BF5 /* HapticList.swift in Sources */,
+				3FC3D7042919E5A1007393DE /* PhoneHomeView.swift in Sources */,
 				3F79FF3528F44F8C002DA8FD /* AnAlternative.swift in Sources */,
 				3FBF057128DA6F0200DA5BF5 /* UsingTheVoiceOverSection.swift in Sources */,
 				3FBF05C328DB4F2200DA5BF5 /* DynamicFontSections.swift in Sources */,
@@ -1032,6 +1039,7 @@
 				3F6C5ABA28E3748A00B12065 /* MultiFingerSwipe.swift in Sources */,
 				3F41C11928E4A4BB0092CF28 /* AdjustLayoutToScaledFontPage.swift in Sources */,
 				3FBF058628DA994400DA5BF5 /* AccessibilityTraitPage.swift in Sources */,
+				3FC3D7062919E651007393DE /* PadHomeView.swift in Sources */,
 				3FBF055728DA661400DA5BF5 /* IndexCell.swift in Sources */,
 				3FBF058828DA9C1B00DA5BF5 /* AccessibilityValuePage.swift in Sources */,
 				3FBF05E828DB641D00DA5BF5 /* Invisibility.swift in Sources */,
@@ -1220,8 +1228,7 @@
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1250,8 +1257,7 @@
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Accessibility Handbook/Book/Colors/Intro/Pages/AboutColorsPage.swift
+++ b/Accessibility Handbook/Book/Colors/Intro/Pages/AboutColorsPage.swift
@@ -19,6 +19,7 @@ struct AboutColorsPage: View, Page {
           .resizable()
           .aspectRatio(contentMode: .fit)
           .accessibilityLabel(L10n.AboutColors.image)
+          .frame(maxWidth: 400.0)
         Text(L10n.AboutColors.text2)
         Comment(L10n.AboutColors.comment2)
         Text(L10n.AboutColors.text3)

--- a/Accessibility Handbook/Book/VoiceOverGuide/UsingTheVoiceOver/Pages/NavigationPage.swift
+++ b/Accessibility Handbook/Book/VoiceOverGuide/UsingTheVoiceOver/Pages/NavigationPage.swift
@@ -36,6 +36,7 @@ private extension NavigationPage {
         .resizable()
         .aspectRatio(contentMode: .fit)
         .accessibilityLabel(L10n.Navigation.image)
+        .frame(maxWidth: 400.0)
       Comment(L10n.Navigation.imageSubtitle)
       Text(L10n.Navigation.text3)
       Text(L10n.Navigation.text4)

--- a/Accessibility Handbook/Home/HomeView.swift
+++ b/Accessibility Handbook/Home/HomeView.swift
@@ -13,10 +13,18 @@ struct HomeView: View {
   @State private var text: String = ""
   @State private var searching: Bool = false
 
+  private var shouldUseLargeContent: Bool {
+    orientation.isLandscape || isIpad
+  }
+
   var body: some View {
     ScrollView(showsIndicators: false) {
       if text.isEmpty {
-        homeContent
+        if isIpad {
+          PadHomeView()
+        } else {
+          PhoneHomeView()
+        }
       } else {
         SearchView(text: $text)
       }
@@ -31,180 +39,6 @@ struct HomeView: View {
         searching.toggle()
       } label: {
         Icon.search
-      }
-    }
-  }
-}
-
-// MARK: - Content
-
-private extension HomeView {
-  var homeContent: some View {
-    VStack(alignment: .center, spacing: .large) {
-      gameCell
-      Title(L10n.Home.developmentGuides)
-      HStack {
-        voiceOverGuide
-        colorsGuide
-      }
-      HStack {
-        dynamicFontsGuide
-        otherGuide
-      }
-      Title(L10n.AboutTheApp.title)
-      HStack {
-        aboutCell
-        collaborationCell
-      }
-      whatsNewCell
-    }
-    .padding()
-  }
-}
-
-// MARK: - GameCell
-
-private extension HomeView {
-  var gameCell: some View {
-    NavigationLink {
-      GameView()
-    } label: {
-      VStack(spacing: .regular) {
-        Spacer()
-        HStack {
-          Spacer()
-          Icon.gameController
-            .resizable()
-            .aspectRatio(contentMode: .fit)
-            .frame(width: 100.0, height: 100.0)
-          Spacer()
-        }
-        Text(L10n.Home.handbookGame)
-          .font(.title3.bold())
-        Comment(L10n.Home.handbookGameDescription)
-      }
-      .frame(maxWidth: 350.0)
-      .accessibilityElement(children: .combine)
-      .padding()
-      .background {
-        RoundedRectangle(cornerRadius: 8.0)
-          .foregroundColor(.secondaryBackground)
-      }
-    }
-  }
-}
-
-// MARK: - Guide Cells
-
-private extension HomeView {
-  private var voiceOverGuide: some View {
-    homeElement(
-      icon: Icon.book,
-      title: L10n.voiceOverGuide,
-      destination: IndexView(sections: VoiceOverGuideSections())
-        .toolbar {
-          NavigationLink {
-            GesturesPage()
-          } label: {
-            Icon.raisedHands
-          }
-          .accessibilityLabel(L10n.Gestures.title)
-        }
-        .toAny()
-    )
-  }
-
-  private var colorsGuide: some View {
-    homeElement(
-      icon: Icon.paintpalete,
-      title: L10n.ColorsGuide.title,
-      destination: IndexView(sections: ColorsSection()).toAny()
-    )
-  }
-
-  private var dynamicFontsGuide: some View {
-    homeElement(
-      icon: Icon.textformat,
-      title: L10n.Home.dynamicFonts,
-      destination: IndexView(sections: DynamicFontSections()).toAny()
-    )
-  }
-
-  private var otherGuide: some View {
-    homeElement(
-      icon: Icon.circleHexagonpath,
-      title: L10n.Home.otherFeatures,
-      destination: IndexView(sections: OthersSections()).toAny()
-    )
-  }
-}
-
-// MARK: - About cells
-
-private extension HomeView {
-  private var aboutCell: some View {
-    homeElement(
-      icon: Icon.questionMarkDashed,
-      title: L10n.AboutTheApp.title,
-      destination: AboutTheAppView().toAny()
-    )
-  }
-
-  private var collaborationCell: some View {
-    homeElement(
-      icon: Icon.textRedaction,
-      title: L10n.Home.collaborate,
-      destination: CollaborationView().toAny()
-    )
-  }
-
-  var whatsNewCell: some View {
-    NavigationLink {
-      WhatsNewView().page
-    } label: {
-      HStack(spacing: .regular) {
-        Icon.bookmark
-          .aspectRatio(contentMode: .fit)
-        Text(L10n.WhatsNew.title)
-          .font(.title3.bold())
-        Spacer()
-      }
-      .frame(maxWidth: 350.0)
-      .accessibilityElement(children: .combine)
-      .padding()
-      .background {
-        RoundedRectangle(cornerRadius: 8.0)
-          .foregroundColor(.secondaryBackground)
-      }
-    }
-  }
-}
-
-private extension HomeView {
-  @ViewBuilder
-  private func homeElement(icon: Image, title: String, destination: AnyView) -> some View {
-    NavigationLink {
-      destination
-    } label: {
-      VStack {
-        Spacer()
-        icon
-          .resizable()
-          .aspectRatio(contentMode: .fit)
-          .frame(width: 50.0, height: 50.0)
-        Spacer()
-        Text(title)
-          .font(.title3.bold())
-        Spacer()
-      }
-      .accessibilityElement(children: .combine)
-      .frame(minWidth: isIpad ? 150.0 : nil,
-             maxWidth: isIpad ? nil : UIScreen.main.bounds.width / 2,
-             minHeight: 150.0)
-      .padding()
-      .background {
-        RoundedRectangle(cornerRadius: 8.0)
-          .foregroundColor(.secondaryBackground)
       }
     }
   }

--- a/Accessibility Handbook/Home/PadHomeView.swift
+++ b/Accessibility Handbook/Home/PadHomeView.swift
@@ -18,6 +18,16 @@ struct PadHomeView: View {
   }
 }
 
+// MARK: - Constants
+
+extension PadHomeView {
+  enum Constants {
+    static let largeIcon: CGFloat = 50.0
+    static let smallIcon: CGFloat = 30.0
+    static let maxItemWidth: CGFloat = UIScreen.main.bounds.width / 4.5
+  }
+}
+
 // MARK: - Content
 
 private extension PadHomeView {
@@ -29,11 +39,15 @@ private extension PadHomeView {
         Title(L10n.Home.developmentGuides)
         Spacer()
       }
-      HStack { guides }
+      .padding(.horizontal, .small)
       HStack {
-        Title("Shortcuts")
+        guides
+      }
+      HStack {
+        Title(L10n.Home.shortcuts)
         Spacer()
       }
+      .padding(.horizontal, .small)
       VStack {
         HStack {
           shortcuts
@@ -46,9 +60,13 @@ private extension PadHomeView {
         Title(L10n.AboutTheApp.title)
         Spacer()
       }
-      HStack { abouts }
+      .padding(.horizontal, .small)
+      HStack {
+        abouts
+      }
     }
-    .padding()
+    .padding(.vertical)
+    .padding(.horizontal, .large)
   }
 
   @ViewBuilder
@@ -117,7 +135,7 @@ private extension PadHomeView {
     )
     shortcutElement(
       icon: Icon.paintbrush,
-      title: "Colors",
+      title: L10n.Home.colors,
       destination: AboutColorsPage().page
     )
     shortcutElement(
@@ -127,7 +145,7 @@ private extension PadHomeView {
     )
     shortcutElement(
       icon: Icon.exclamation,
-      title: "Notifications",
+      title: L10n.Home.notifications,
       destination: AnnouncementPage().page
     )
   }
@@ -163,7 +181,7 @@ private extension PadHomeView {
         Icon.gameController
           .resizable()
           .aspectRatio(contentMode: .fit)
-          .frame(width: 50.0, height: 50.0)
+          .frame(width: Constants.largeIcon, height: Constants.largeIcon)
         HorizontalSpace(.regular)
         VStack(alignment: .leading, spacing: .small) {
           Text(L10n.Home.handbookGame)
@@ -192,22 +210,30 @@ private extension PadHomeView {
         icon
           .resizable()
           .aspectRatio(contentMode: .fit)
-          .frame(width: 30.0, height: 30.0)
+          .frame(
+            width: Constants.smallIcon,
+            height: Constants.smallIcon
+          )
         HorizontalSpace(.regular)
         Text(title)
           .font(.body.bold())
           .multilineTextAlignment(.leading)
+          .minimumScaleFactor(0.5)
         Spacer()
       }
       .accessibilityElement(children: .combine)
-      .frame(minWidth: 150.0,
-             minHeight: 50.0)
+      .frame(
+        minHeight: 45.0
+      )
       .padding()
       .background {
         RoundedRectangle(cornerRadius: 8.0)
           .foregroundColor(.secondaryBackground)
       }
     }
+    .frame(
+      maxWidth: Constants.maxItemWidth
+    )
   }
 
   @ViewBuilder
@@ -220,20 +246,26 @@ private extension PadHomeView {
         icon
           .resizable()
           .aspectRatio(contentMode: .fit)
-          .frame(width: 50.0, height: 50.0)
+          .frame(width: Constants.largeIcon, height: Constants.largeIcon)
         Spacer()
         Text(title)
           .font(.title3.bold())
         Spacer()
       }
       .accessibilityElement(children: .combine)
-      .frame(minWidth: 150.0,
-             minHeight: 100.0)
+      .frame(
+        minWidth: 150.0,
+        maxWidth: UIScreen.main.bounds.width / 4.7,
+        minHeight: 100.0
+      )
       .padding()
       .background {
         RoundedRectangle(cornerRadius: 8.0)
           .foregroundColor(.secondaryBackground)
       }
     }
+    .frame(
+      maxWidth: Constants.maxItemWidth
+    )
   }
 }

--- a/Accessibility Handbook/Home/PadHomeView.swift
+++ b/Accessibility Handbook/Home/PadHomeView.swift
@@ -1,0 +1,239 @@
+//
+//  PhoneHomeView.swift
+//  Accessibility Handbook
+//
+//  Created by Giovani Nascimento Pereira on 07/11/22.
+//
+
+import SwiftUI
+
+struct PadHomeView: View {
+  @State private var orientation: UIDeviceOrientation = UIDevice.current.orientation
+
+  var body: some View {
+    homeContent
+    .onRotate { newOrientation in
+      orientation = newOrientation
+    }
+  }
+}
+
+// MARK: - Content
+
+private extension PadHomeView {
+  @ViewBuilder
+  var homeContent: some View {
+    VStack(alignment: .center, spacing: .large) {
+      gameCell
+      HStack {
+        Title(L10n.Home.developmentGuides)
+        Spacer()
+      }
+      HStack { guides }
+      HStack {
+        Title("Shortcuts")
+        Spacer()
+      }
+      VStack {
+        HStack {
+          shortcuts
+        }
+        HStack {
+          shortcuts2
+        }
+      }
+      HStack {
+        Title(L10n.AboutTheApp.title)
+        Spacer()
+      }
+      HStack { abouts }
+    }
+    .padding()
+  }
+
+  @ViewBuilder
+  var guides: some View {
+    homeElement(
+      icon: Icon.book,
+      title: L10n.voiceOverGuide,
+      destination: IndexView(sections: VoiceOverGuideSections())
+        .toolbar {
+          NavigationLink {
+            GesturesPage()
+          } label: {
+            Icon.raisedHands
+          }
+          .accessibilityLabel(L10n.Gestures.title)
+        }
+        .toAny()
+    )
+    homeElement(
+      icon: Icon.paintpalete,
+      title: L10n.ColorsGuide.title,
+      destination: IndexView(sections: ColorsSection()).toAny()
+    )
+    homeElement(
+      icon: Icon.textformat,
+      title: L10n.Home.dynamicFonts,
+      destination: IndexView(sections: DynamicFontSections()).toAny()
+    )
+    homeElement(
+      icon: Icon.circleHexagonpath,
+      title: L10n.Home.otherFeatures,
+      destination: IndexView(sections: OthersSections()).toAny()
+    )
+  }
+
+  @ViewBuilder
+  var shortcuts: some View {
+    shortcutElement(
+      icon: Icon.raisedHands,
+      title: L10n.Gestures.title,
+      destination: GesturesPage().page
+    )
+    shortcutElement(
+      icon: Icon.eyeglasses,
+      title: L10n.visualAid,
+      destination: ButtonShapesPage().page
+    )
+    shortcutElement(
+      icon: Icon.lightSwitch,
+      title: L10n.darkMode,
+      destination: WhatIsDarkModePage().page
+    )
+    shortcutElement(
+      icon: Icon._3d,
+      title: L10n.motion,
+      destination: ReduceMotionPage().page
+    )
+  }
+
+  @ViewBuilder
+  var shortcuts2: some View {
+    shortcutElement(
+      icon: Icon.tap,
+      title: L10n.interactrion,
+      destination: ActivatePage().page
+    )
+    shortcutElement(
+      icon: Icon.paintbrush,
+      title: "Colors",
+      destination: AboutColorsPage().page
+    )
+    shortcutElement(
+      icon: Icon.vibrations,
+      title: L10n.haptics,
+      destination: HapticsPage().page
+    )
+    shortcutElement(
+      icon: Icon.exclamation,
+      title: "Notifications",
+      destination: AnnouncementPage().page
+    )
+  }
+
+  @ViewBuilder
+  var abouts: some View {
+    homeElement(
+      icon: Icon.questionMarkDashed,
+      title: L10n.AboutTheApp.title,
+      destination: AboutTheAppView().toAny()
+    )
+    homeElement(
+      icon: Icon.textRedaction,
+      title: L10n.Home.collaborate,
+      destination: CollaborationView().toAny()
+    )
+    homeElement(
+      icon: Icon.bookmark,
+      title: L10n.WhatsNew.title,
+      destination: WhatsNewView().toAny()
+    )
+  }
+}
+
+// MARK: - GameCell
+
+private extension PadHomeView {
+  var gameCell: some View {
+    NavigationLink {
+      GameView()
+    } label: {
+      HStack(spacing: .regular) {
+        Icon.gameController
+          .resizable()
+          .aspectRatio(contentMode: .fit)
+          .frame(width: 50.0, height: 50.0)
+        HorizontalSpace(.regular)
+        VStack(alignment: .leading, spacing: .small) {
+          Text(L10n.Home.handbookGame)
+            .font(.title3.bold())
+          Comment(L10n.Home.handbookGameDescription)
+        }
+      }
+      .frame(maxWidth: .infinity)
+      .accessibilityElement(children: .combine)
+      .padding()
+      .background {
+        RoundedRectangle(cornerRadius: 8.0)
+          .foregroundColor(.secondaryBackground)
+      }
+    }
+  }
+}
+
+private extension PadHomeView {
+  @ViewBuilder
+  private func shortcutElement(icon: Image, title: String, destination: AnyView) -> some View {
+    NavigationLink {
+      destination
+    } label: {
+      HStack {
+        icon
+          .resizable()
+          .aspectRatio(contentMode: .fit)
+          .frame(width: 30.0, height: 30.0)
+        HorizontalSpace(.regular)
+        Text(title)
+          .font(.body.bold())
+          .multilineTextAlignment(.leading)
+        Spacer()
+      }
+      .accessibilityElement(children: .combine)
+      .frame(minWidth: 150.0,
+             minHeight: 50.0)
+      .padding()
+      .background {
+        RoundedRectangle(cornerRadius: 8.0)
+          .foregroundColor(.secondaryBackground)
+      }
+    }
+  }
+
+  @ViewBuilder
+  private func homeElement(icon: Image, title: String, destination: AnyView) -> some View {
+    NavigationLink {
+      destination
+    } label: {
+      VStack {
+        Spacer()
+        icon
+          .resizable()
+          .aspectRatio(contentMode: .fit)
+          .frame(width: 50.0, height: 50.0)
+        Spacer()
+        Text(title)
+          .font(.title3.bold())
+        Spacer()
+      }
+      .accessibilityElement(children: .combine)
+      .frame(minWidth: 150.0,
+             minHeight: 100.0)
+      .padding()
+      .background {
+        RoundedRectangle(cornerRadius: 8.0)
+          .foregroundColor(.secondaryBackground)
+      }
+    }
+  }
+}

--- a/Accessibility Handbook/Home/PhoneHomeView.swift
+++ b/Accessibility Handbook/Home/PhoneHomeView.swift
@@ -1,0 +1,298 @@
+//
+//  PhoneHomeView.swift
+//  Accessibility Handbook
+//
+//  Created by Giovani Nascimento Pereira on 07/11/22.
+//
+
+import SwiftUI
+
+struct PhoneHomeView: View {
+  @State private var orientation: UIDeviceOrientation = UIDevice.current.orientation
+
+  var body: some View {
+    homeContent
+    .onRotate { newOrientation in
+      orientation = newOrientation
+    }
+  }
+}
+
+// MARK: - Content
+
+private extension PhoneHomeView {
+  @ViewBuilder
+  var homeContent: some View {
+    if orientation.isLandscape {
+      landscapeHomeContent
+    } else {
+      portraitHomeContent
+    }
+  }
+
+  var portraitHomeContent: some View {
+    VStack(alignment: .center, spacing: .large) {
+      portraitGameCell
+      Title(L10n.Home.developmentGuides)
+      HStack {
+        voiceOverGuide
+        colorsGuide
+      }
+      HStack {
+        dynamicFontsGuide
+        otherGuide
+      }
+      Title(L10n.AboutTheApp.title)
+      HStack {
+        aboutCell
+        collaborationCell
+      }
+      whatsNewCell
+    }
+    .padding()
+  }
+
+  var landscapeHomeContent: some View {
+    VStack(alignment: .center, spacing: .large) {
+      landscapeGameCell
+      HStack {
+        Title(L10n.Home.developmentGuides)
+        Spacer()
+      }
+      HStack {
+        voiceOverGuide
+        colorsGuide
+        dynamicFontsGuide
+        otherGuide
+      }
+      HStack {
+        Title(L10n.AboutTheApp.title)
+        Spacer()
+      }
+      HStack {
+        aboutCell
+        collaborationCell
+        whatsNewCell
+      }
+    }
+    .padding()
+  }
+}
+
+// MARK: - GameCell
+
+private extension PhoneHomeView {
+  var portraitGameCell: some View {
+    NavigationLink {
+      GameView()
+    } label: {
+      VStack(spacing: .regular) {
+        Spacer()
+        HStack {
+          Spacer()
+          Icon.gameController
+            .resizable()
+            .aspectRatio(contentMode: .fit)
+            .frame(width: 100.0, height: 100.0)
+          Spacer()
+        }
+        Text(L10n.Home.handbookGame)
+          .font(.title3.bold())
+        Comment(L10n.Home.handbookGameDescription)
+      }
+      .frame(maxWidth: 350.0)
+      .accessibilityElement(children: .combine)
+      .padding()
+      .background {
+        RoundedRectangle(cornerRadius: 8.0)
+          .foregroundColor(.secondaryBackground)
+      }
+    }
+  }
+
+  var landscapeGameCell: some View {
+    NavigationLink {
+      GameView()
+    } label: {
+      HStack(spacing: .regular) {
+        Icon.gameController
+          .resizable()
+          .aspectRatio(contentMode: .fit)
+          .frame(width: 50.0, height: 50.0)
+        HorizontalSpace(.regular)
+        VStack(alignment: .leading, spacing: .small) {
+          Text(L10n.Home.handbookGame)
+            .font(.title3.bold())
+          Comment(L10n.Home.handbookGameDescription)
+        }
+      }
+      .frame(maxWidth: .infinity)
+      .accessibilityElement(children: .combine)
+      .padding()
+      .background {
+        RoundedRectangle(cornerRadius: 8.0)
+          .foregroundColor(.secondaryBackground)
+      }
+    }
+  }
+}
+
+// MARK: - Guide Cells
+
+private extension PhoneHomeView {
+  private var voiceOverGuide: some View {
+    homeElement(
+      icon: Icon.book,
+      title: L10n.voiceOverGuide,
+      destination: IndexView(sections: VoiceOverGuideSections())
+        .toolbar {
+          NavigationLink {
+            GesturesPage()
+          } label: {
+            Icon.raisedHands
+          }
+          .accessibilityLabel(L10n.Gestures.title)
+        }
+        .toAny()
+    )
+  }
+
+  private var colorsGuide: some View {
+    homeElement(
+      icon: Icon.paintpalete,
+      title: L10n.ColorsGuide.title,
+      destination: IndexView(sections: ColorsSection()).toAny()
+    )
+  }
+
+  private var dynamicFontsGuide: some View {
+    homeElement(
+      icon: Icon.textformat,
+      title: L10n.Home.dynamicFonts,
+      destination: IndexView(sections: DynamicFontSections()).toAny()
+    )
+  }
+
+  private var otherGuide: some View {
+    homeElement(
+      icon: Icon.circleHexagonpath,
+      title: L10n.Home.otherFeatures,
+      destination: IndexView(sections: OthersSections()).toAny()
+    )
+  }
+}
+
+// MARK: - About cells
+
+private extension PhoneHomeView {
+  private var aboutCell: some View {
+    homeElement(
+      icon: Icon.questionMarkDashed,
+      title: L10n.AboutTheApp.title,
+      destination: AboutTheAppView().toAny()
+    )
+  }
+
+  private var collaborationCell: some View {
+    homeElement(
+      icon: Icon.textRedaction,
+      title: L10n.Home.collaborate,
+      destination: CollaborationView().toAny()
+    )
+  }
+
+  @ViewBuilder
+  var whatsNewCell: some View {
+    if orientation.isLandscape {
+      homeElement(
+        icon: Icon.bookmark,
+        title: L10n.WhatsNew.title,
+        destination: WhatsNewView().toAny()
+      )
+    } else {
+      NavigationLink {
+        WhatsNewView().page
+      } label: {
+        HStack(spacing: .regular) {
+          Icon.bookmark
+            .aspectRatio(contentMode: .fit)
+          Text(L10n.WhatsNew.title)
+            .font(.title3.bold())
+          Spacer()
+        }
+        .frame(maxWidth: 350.0)
+        .accessibilityElement(children: .combine)
+        .padding()
+        .background {
+          RoundedRectangle(cornerRadius: 8.0)
+            .foregroundColor(.secondaryBackground)
+        }
+      }
+    }
+  }
+}
+
+private extension PhoneHomeView {
+  @ViewBuilder
+  private func homeElement(icon: Image, title: String, destination: AnyView) -> some View {
+    if orientation.isLandscape {
+      largeHomeElement(icon: icon, title: title, destination: destination)
+    } else {
+      regularHomeElement(icon: icon, title: title, destination: destination)
+    }
+  }
+
+  @ViewBuilder
+  private func regularHomeElement(icon: Image, title: String, destination: AnyView) -> some View {
+    NavigationLink {
+      destination
+    } label: {
+      VStack {
+        Spacer()
+        icon
+          .resizable()
+          .aspectRatio(contentMode: .fit)
+          .frame(width: 50.0, height: 50.0)
+        Spacer()
+        Text(title)
+          .font(.title3.bold())
+        Spacer()
+      }
+      .accessibilityElement(children: .combine)
+      .frame(maxWidth: UIScreen.main.bounds.width / 2,
+             minHeight: 150.0)
+      .padding()
+      .background {
+        RoundedRectangle(cornerRadius: 8.0)
+          .foregroundColor(.secondaryBackground)
+      }
+    }
+  }
+
+  @ViewBuilder
+  private func largeHomeElement(icon: Image, title: String, destination: AnyView) -> some View {
+    NavigationLink {
+      destination
+    } label: {
+      VStack {
+        Spacer()
+        icon
+          .resizable()
+          .aspectRatio(contentMode: .fit)
+          .frame(width: 30.0, height: 30.0)
+        Spacer()
+        Text(title)
+          .font(.title3.bold())
+        Spacer()
+      }
+      .accessibilityElement(children: .combine)
+      .frame(maxWidth: UIScreen.main.bounds.width / 2,
+             minHeight: 100.0)
+      .padding()
+      .background {
+        RoundedRectangle(cornerRadius: 8.0)
+          .foregroundColor(.secondaryBackground)
+      }
+    }
+  }
+}

--- a/Accessibility Handbook/Strings/Strings.swift
+++ b/Accessibility Handbook/Strings/Strings.swift
@@ -1314,6 +1314,8 @@ internal enum L10n {
   internal enum Home {
     /// Collaborate
     internal static let collaborate = L10n.tr("Localizable", "Home.collaborate")
+    /// Colors
+    internal static let colors = L10n.tr("Localizable", "Home.colors")
     /// Development Guides
     internal static let developmentGuides = L10n.tr("Localizable", "Home.developmentGuides")
     /// Dynamic Fonts
@@ -1322,8 +1324,12 @@ internal enum L10n {
     internal static let handbookGame = L10n.tr("Localizable", "Home.handbookGame")
     /// Test your accessibility knowledge in a series of puzzles!
     internal static let handbookGameDescription = L10n.tr("Localizable", "Home.handbookGameDescription")
+    /// Notifications
+    internal static let notifications = L10n.tr("Localizable", "Home.notifications")
     /// Other Features
     internal static let otherFeatures = L10n.tr("Localizable", "Home.otherFeatures")
+    /// Shortcuts
+    internal static let shortcuts = L10n.tr("Localizable", "Home.shortcuts")
   }
 
   internal enum IdentifyCurrentPreferredFontSizePage {

--- a/Accessibility Handbook/Strings/Strings.swift
+++ b/Accessibility Handbook/Strings/Strings.swift
@@ -1324,7 +1324,7 @@ internal enum L10n {
     internal static let handbookGame = L10n.tr("Localizable", "Home.handbookGame")
     /// Test your accessibility knowledge in a series of puzzles!
     internal static let handbookGameDescription = L10n.tr("Localizable", "Home.handbookGameDescription")
-    /// Notifications
+    /// Notify
     internal static let notifications = L10n.tr("Localizable", "Home.notifications")
     /// Other Features
     internal static let otherFeatures = L10n.tr("Localizable", "Home.otherFeatures")

--- a/Accessibility Handbook/Strings/en.lproj/Localizable.strings
+++ b/Accessibility Handbook/Strings/en.lproj/Localizable.strings
@@ -27,7 +27,7 @@
 "Home.collaborate" = "Collaborate";
 "Home.shortcuts" = "Shortcuts";
 "Home.colors" = "Colors";
-"Home.notifications" = "Notifications";
+"Home.notifications" = "Notify";
 
 // WhatsNew
 

--- a/Accessibility Handbook/Strings/en.lproj/Localizable.strings
+++ b/Accessibility Handbook/Strings/en.lproj/Localizable.strings
@@ -25,6 +25,9 @@
 "Home.dynamicFonts" = "Dynamic Fonts";
 "Home.otherFeatures" = "Other Features";
 "Home.collaborate" = "Collaborate";
+"Home.shortcuts" = "Shortcuts";
+"Home.colors" = "Colors";
+"Home.notifications" = "Notifications";
 
 // WhatsNew
 

--- a/Accessibility Handbook/Strings/pt-BR.lproj/Localizable.strings
+++ b/Accessibility Handbook/Strings/pt-BR.lproj/Localizable.strings
@@ -25,6 +25,9 @@
 "Home.dynamicFonts" = "Fontes dinâmicas";
 "Home.otherFeatures" = "Outras features";
 "Home.collaborate" = "Colabore";
+"Home.shortcuts" = "Atalhos";
+"Home.colors" = "Cores";
+"Home.notifications" = "Notificações";
 
 // WhatsNew
 

--- a/Accessibility Handbook/Strings/pt-BR.lproj/Localizable.strings
+++ b/Accessibility Handbook/Strings/pt-BR.lproj/Localizable.strings
@@ -27,7 +27,7 @@
 "Home.collaborate" = "Colabore";
 "Home.shortcuts" = "Atalhos";
 "Home.colors" = "Cores";
-"Home.notifications" = "Notificações";
+"Home.notifications" = "Notificar";
 
 // WhatsNew
 

--- a/Accessibility Handbook/UI/Icons.swift
+++ b/Accessibility Handbook/UI/Icons.swift
@@ -43,6 +43,13 @@ enum Icon {
   static let raisedHands = Image(systemName: "hand.raised.fill")
   static let search = Image(systemName: "magnifyingglass")
   static let bookmark = Image(systemName: "bookmark.fill")
+  static let eyeglasses = Image(systemName: "eyeglasses")
+  static let lightSwitch = Image(systemName: "lightswitch.off.square.fill")
+  static let _3d = Image(systemName: "move.3d")
+  static let tap = Image(systemName: "hand.tap.fill")
+  static let paintbrush = Image(systemName: "paintbrush.fill")
+  static let vibrations = Image(systemName: "dot.radiowaves.left.and.right")
+  static let exclamation = Image(systemName: "exclamationmark.circle.fill")
 
   // State
   static let checkmark = Image(systemName: "checkmark.circle.fill")

--- a/Accessibility Handbook/UI/PageContent.swift
+++ b/Accessibility Handbook/UI/PageContent.swift
@@ -12,7 +12,6 @@ struct PageContent: View {
   let deeplink: String
   let content: () -> AnyView
 
-  @State private var isIpad = UITraitCollection.current.userInterfaceIdiom == .pad
   @Environment(\.dismiss) var dismiss
 
   var body: some View {
@@ -26,7 +25,6 @@ struct PageContent: View {
           Spacer()
         }
       }
-      .frame(width: isIpad ? UIScreen.main.bounds.width * 0.9 : nil)
       HStack {
         Spacer()
         if let next = next {

--- a/Accessibility Handbook/UI/PageContent.swift
+++ b/Accessibility Handbook/UI/PageContent.swift
@@ -12,6 +12,7 @@ struct PageContent: View {
   let deeplink: String
   let content: () -> AnyView
 
+  @State private var isIpad = UITraitCollection.current.userInterfaceIdiom == .pad
   @Environment(\.dismiss) var dismiss
 
   var body: some View {
@@ -25,6 +26,7 @@ struct PageContent: View {
           Spacer()
         }
       }
+      .frame(width: isIpad ? UIScreen.main.bounds.width * 0.9 : nil)
       HStack {
         Spacer()
         if let next = next {


### PR DESCRIPTION
### Summary

- The focus of this PR is improving the home screen on both iPad and Landscape iPhone

### Implementation details

- We now have 2 separate home screen codes
  - one for iPhone
  - the other for iPad 
- This allows us to make better use of the iPad size to display more content
- And to improve visibility on iPhone landscape

### How to test it?

- Just run the app on iPhones and iPads and test it while in landscape!

### Evidence

|  <img width="564" alt="Screenshot 2022-11-07 at 23 21 14" src="https://user-images.githubusercontent.com/12978176/200459507-80a61f71-30c9-4ecd-bf1e-263c0677b48b.png"> |  <img width="1000" alt="Screenshot 2022-11-07 at 23 21 19" src="https://user-images.githubusercontent.com/12978176/200459538-4cffe9c9-eef3-4ae4-8721-d4ad6790635d.png"> |  <img width="781" alt="Screenshot 2022-11-07 at 23 00 27" src="https://user-images.githubusercontent.com/12978176/200459545-870eb1d2-3aad-4fb4-9e07-6e08dd87c2e5.png"> |
|--|--|--|
