### PR TITLE
Fixing orientation on home view list subpages

### DIFF
--- a/Accessibility Handbook/Home/HomeView.swift
+++ b/Accessibility Handbook/Home/HomeView.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 struct HomeView: View {
-  @State private var orientation: UIDeviceOrientation = UIDevice.current.orientation
   @State private var text: String = ""
   @State private var searching: Bool = false
 
@@ -36,9 +35,6 @@ struct HomeView: View {
     }
     .searchable(text: $text, placement: .navigationBarDrawer(displayMode: searching ? .always : .automatic))
     .navigationTitle(L10n.handbook)
-    .onRotate { newOrientation in
-      orientation = newOrientation
-    }
     .toolbar {
       Button {
         searching.toggle()

--- a/Accessibility Handbook/Home/PhoneHomeView.swift
+++ b/Accessibility Handbook/Home/PhoneHomeView.swift
@@ -9,10 +9,19 @@ import SwiftUI
 
 struct PhoneHomeView: View {
   @State private var orientation: UIDeviceOrientation = UIDevice.current.orientation
+  @State var isOnScreen: Bool = true
 
   var body: some View {
     homeContent
+      .onAppear {
+        isOnScreen = true
+        orientation = UIDevice.current.orientation
+      }
+      .onDisappear {
+        isOnScreen = false
+      }
     .onRotate { newOrientation in
+      guard isOnScreen else { return }
       orientation = newOrientation
     }
   }


### PR DESCRIPTION
## Summary

Fixing orientation change on home to only happen when the view is on screen

### Implementation details

Removed unnecessary orientation, changes the orientation on home to only detect if it is on screen. The problem in the previous implementation happened because the view would still be alive since it was on the hierarchy, so when the device orientation changed the action would trigger updating the orientation variable. Since it was stateful the state of the view would change triggering a view layout update and that caused the navigation to go back

### How to test it?

 Go to a list page from the home and change the device orientation. You will no longer be taken back to the home

### Evidences

https://user-images.githubusercontent.com/99685544/207957184-e0b340cf-eced-437c-b722-60a978705998.mov


